### PR TITLE
Move the Packages struct to package.go

### DIFF
--- a/parse/package.go
+++ b/parse/package.go
@@ -32,6 +32,10 @@ type Package struct {
 	PanicEvents []*Event
 }
 
+// Packages is a collection of packages being tested.
+// TODO: this should really be a consoleWriter... would benefit from a nice refactor.
+type Packages map[string]*Package
+
 // NewPackage initializes and returns a Package.
 func NewPackage() *Package {
 	return &Package{

--- a/parse/process.go
+++ b/parse/process.go
@@ -15,10 +15,6 @@ import (
 // by the Process func.
 var ErrNotParseable = errors.New("failed to parse events")
 
-// Packages is a collection of packages being tested.
-// TODO: this should really be a consoleWriter... would benefit from a nice refactor.
-type Packages map[string]*Package
-
 // Process is the entry point to the parse pkg. It consumes a reader
 // and attempts to parse go test JSON output lines until EOF.
 //


### PR DESCRIPTION
I think the `Packages` struct (it is just map of `Package` struct) should be located in `package.go`. `process.go` still can refer the `Packages` struct, because `process.go` also belongs to the `parse` package.