### PR TITLE
Fixes #28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 before_install:
-  - go get github.com/mfridman/tparse
+  - go get -u github.com/mfridman/tparse
 
 go:
   - "1.10"
@@ -15,4 +15,4 @@ branches:
     - devel
 
 script:
-  - go test -v ./parse -json -cover | tparse -all -smallscreen
+  - go test -race -v ./parse -json -cover | tparse -all -smallscreen

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ test:
 
 # eating our own dog food :)
 test-tparse-full:
-	go test -count=1 -v ./... -json -cover | go run main.go -all -smallscreen -notests
+	go test -race-count=1 -v ./... -json -cover | go run main.go -all -smallscreen -notests
 
 test-tparse:
-	go test -count=1 ./parse -json -cover | go run main.go
+	go test -race -count=1 ./parse -json -cover | go run main.go
 
 release:
 	goreleaser --rm-dist

--- a/main.go
+++ b/main.go
@@ -79,16 +79,19 @@ func main() {
 
 	pkgs, err := parse.Process(tr)
 	if err != nil {
-		if err == parse.ErrNotParseable {
+		switch {
+		case err == parse.ErrNotParseable:
 			fmt.Fprintf(os.Stderr, "tparse error: no parseable events: call go test with -json flag\n\n")
 			if *dumpPtr {
 				parse.ReplayOutput(os.Stderr, &replayBuf)
 			}
-			os.Exit(1)
+		case err == parse.ErrRaceDetected:
+			fmt.Fprintf(os.Stderr, "tparse error: %v\n\n", err)
+			parse.ReplayRaceOutput(os.Stderr, &replayBuf)
+		default:
+			fmt.Fprintf(os.Stderr, "tparse error: %v\n\n", err)
+			parse.ReplayOutput(os.Stderr, &replayBuf)
 		}
-
-		fmt.Fprintf(os.Stderr, "tparse error: %v\n\n", err)
-		parse.ReplayOutput(os.Stderr, &replayBuf)
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -79,13 +79,13 @@ func main() {
 
 	pkgs, err := parse.Process(tr)
 	if err != nil {
-		switch {
-		case err == parse.ErrNotParseable:
+		switch err {
+		case parse.ErrNotParseable:
 			fmt.Fprintf(os.Stderr, "tparse error: no parseable events: call go test with -json flag\n\n")
 			if *dumpPtr {
 				parse.ReplayOutput(os.Stderr, &replayBuf)
 			}
-		case err == parse.ErrRaceDetected:
+		case parse.ErrRaceDetected:
 			fmt.Fprintf(os.Stderr, "tparse error: %v\n\n", err)
 			parse.ReplayRaceOutput(os.Stderr, &replayBuf)
 		default:

--- a/parse/event.go
+++ b/parse/event.go
@@ -53,7 +53,9 @@ func NewEvent(data []byte) (*Event, error) {
 type Events []*Event
 
 // Discard reports whether an "output" action:
-// 1. is an update action: RUN, PAUSE, CONT.
+//
+// 1. is an update action: RUN, PAUSE, CONT
+//
 // 2. has no test name
 //
 // If output is not one of the above return false.
@@ -140,6 +142,11 @@ func (e *Event) Cover() (float64, bool) {
 	}
 
 	return f, false
+}
+
+// IsRace indicates a race event has been detected.
+func (e *Event) IsRace() bool {
+	return strings.HasPrefix(e.Output, "WARNING: DATA RACE")
 }
 
 // IsPanic indicates a panic event has been detected.

--- a/parse/package.go
+++ b/parse/package.go
@@ -56,20 +56,28 @@ func NewPackage() *Package {
 
 // AddEvent adds the event to a test based on test name.
 func (p *Package) AddEvent(event *Event) {
+	var t *Test
+	if t = p.GetTest(event.Test); t == nil {
+		// Test does not exist, add it to pkg.
+		t = &Test{
+			Name:    event.Test,
+			Package: event.Package,
+		}
+		p.Tests = append(p.Tests, t)
+	}
+
+	t.Events = append(t.Events, event)
+}
+
+// GetTest retuns a test based on given name, if no test is found
+// return nil
+func (p *Package) GetTest(name string) *Test {
 	for _, t := range p.Tests {
-		if t.Name == event.Test {
-			t.Events = append(t.Events, event)
-			return
+		if t.Name == name {
+			return t
 		}
 	}
-
-	t := &Test{
-		Name:    event.Test,
-		Package: event.Package,
-	}
-	t.Events = append(t.Events, event)
-
-	p.Tests = append(p.Tests, t)
+	return nil
 }
 
 // TestsByAction returns all tests that identify as one of the following

--- a/parse/prescan_test.go
+++ b/parse/prescan_test.go
@@ -27,6 +27,7 @@ func TestPrescan(t *testing.T) {
 		// logic: unparseable event(s), good event(s), at least one event = fail.
 		// Once we get a good event, we expect only good events to follow until EOF.
 		{"input03.txt", "want failure when stream contains a bad event(s) -> good event(s) -> bad event", ErrNotParseable},
+		{"input04.txt", "want failure reading <50 lines of non-parseable events", ErrNotParseable},
 	}
 
 	for _, test := range tt {
@@ -45,8 +46,13 @@ func TestPrescan(t *testing.T) {
 			// retrieve original error.
 			err = errors.Cause(err)
 
+			// dirty, but does the job.
 			if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
 				t.Fatalf("%s: got err type %T want %T: %v", test.desc, err, test.err, err)
+			}
+
+			if err != nil && err != test.err {
+				t.Fatalf("got wrong opaque error %q; want ErrNotParseable", err)
 			}
 
 		})

--- a/parse/process.go
+++ b/parse/process.go
@@ -159,6 +159,7 @@ func ReplayOutput(w io.Writer, r io.Reader) {
 // The race output is non-detertministc.
 // https://github.com/golang/go/issues/29156#issuecomment-445486381
 func ReplayRaceOutput(w io.Writer, r io.Reader) {
+
 	var raceStarted bool
 
 	sc := bufio.NewScanner(r)
@@ -175,6 +176,7 @@ func ReplayRaceOutput(w io.Writer, r io.Reader) {
 				continue
 			}
 			fmt.Fprint(w, e.Output)
+			continue
 		}
 
 		if strings.Contains(e.Output, "==================") {

--- a/parse/process.go
+++ b/parse/process.go
@@ -14,6 +14,10 @@ import (
 // by the Process func.
 var ErrNotParseable = errors.New("failed to parse events")
 
+// ErrRaceDetected indicates a race condition has been detected during execution.
+// Returned by the Process func.
+var ErrRaceDetected = errors.New("race detected")
+
 // Process is the entry point to the parse pkg. It consumes a reader
 // and attempts to parse go test JSON output lines until EOF.
 //
@@ -23,6 +27,8 @@ var ErrNotParseable = errors.New("failed to parse events")
 func Process(r io.Reader) (Packages, error) {
 
 	pkgs := Packages{}
+
+	var hasRace bool
 
 	var scan bool
 	var badLines int
@@ -58,9 +64,14 @@ func Process(r io.Reader) (Packages, error) {
 			pkg.Summary.Package = e.Package
 			pkg.Summary.Test = e.Test
 		}
+		// Short circuit output when panic is detected.
 		if pkg.HasPanic {
 			pkg.PanicEvents = append(pkg.PanicEvents, e)
 			continue
+		}
+
+		if e.IsRace() {
+			hasRace = true
 		}
 
 		if e.IsCached() {
@@ -109,6 +120,9 @@ func Process(r io.Reader) (Packages, error) {
 	if !scan {
 		return nil, ErrNotParseable
 	}
+	if hasRace {
+		return nil, ErrRaceDetected
+	}
 
 	return pkgs, nil
 }
@@ -130,6 +144,43 @@ func ReplayOutput(w io.Writer, r io.Reader) {
 		}
 		// Output expected to be terminated by a newline.
 		fmt.Fprint(w, e.Output)
+	}
+
+	if err := sc.Err(); err != nil {
+		fmt.Fprintf(w, "tparse scan error: %v\n", err)
+	}
+}
+
+// ReplayRaceOutput takes json event lines from r and returns partial output
+// to w. Specifically, once a race is detected all discard and PASS events will
+// be ignored. This is to keep output as close as possible to what
+// go test (without -v) would have otherwise returned.
+//
+// The race output is non-detertministc.
+// https://github.com/golang/go/issues/29156#issuecomment-445486381
+func ReplayRaceOutput(w io.Writer, r io.Reader) {
+	var raceStarted bool
+
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		e, err := NewEvent(sc.Bytes())
+		if err != nil {
+			// We couldn't parse an event, so return the raw text.
+			fmt.Fprintln(w, strings.TrimSpace(sc.Text()))
+			continue
+		}
+
+		if raceStarted {
+			if e.Discard() || strings.Contains(e.Output, "--- PASS:") {
+				continue
+			}
+			fmt.Fprint(w, e.Output)
+		}
+
+		if strings.Contains(e.Output, "==================") {
+			raceStarted = true
+			fmt.Fprint(w, e.Output)
+		}
 	}
 
 	if err := sc.Err(); err != nil {

--- a/parse/race_test.go
+++ b/parse/race_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 )
 
-func TestReplay(t *testing.T) {
+func TestRaceReplay(t *testing.T) {
 
 	root := "testdata"
-	base := filepath.Join(root, "replay")
+	base := filepath.Join(root, "race")
 
 	tt := []struct {
 		name, input, output string
@@ -34,10 +34,10 @@ func TestReplay(t *testing.T) {
 			}
 
 			var buf bytes.Buffer
-			ReplayOutput(&buf, f)
+			ReplayRaceOutput(&buf, f)
 
 			if !bytes.Equal(buf.Bytes(), want) {
-				t.Error("replay input does not match expected output; diff files in replay dir suffixed with .FAIL to debug")
+				t.Error("race input does not match expected output; diff files in race dir suffixed with .FAIL to debug")
 				t.Logf("diff %v %v", "parse/"+test.input+".FAIL", "parse/"+test.output+".FAIL")
 				if err := ioutil.WriteFile(test.input+".FAIL", buf.Bytes(), 0644); err != nil {
 					t.Fatal(err)
@@ -46,6 +46,15 @@ func TestReplay(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
+
+			if _, err := f.Seek(0, 0); err != nil {
+				t.Fatalf("failed to seek back to begining of file: %v", err)
+			}
+
+			if _, err := Process(f); err != ErrRaceDetected {
+				t.Fatalf("got wrong opaque error %q; want ErrRaceDetected", err)
+			}
+
 		})
 
 	}

--- a/parse/testdata/prescan/input04.txt
+++ b/parse/testdata/prescan/input04.txt
@@ -1,0 +1,25 @@
+Previous write at 0x00c000090090 by goroutine 6:
+  debug/tparse-24.TestRace()
+      /Users/michael.fridman/go/src/debug/tparse-24/some_test.go:8 +0x88
+  testing.tRunner()
+      /usr/local/go/src/testing/testing.go:827 +0x162
+
+Goroutine 7 (running) created at:
+  debug/tparse-24.TestRace()
+      /Users/michael.fridman/go/src/debug/tparse-24/some_test.go:7 +0x7a
+  testing.tRunner()
+      /usr/local/go/src/testing/testing.go:827 +0x162
+
+Goroutine 6 (running) created at:
+  testing.(*T).Run()
+      /usr/local/go/src/testing/testing.go:878 +0x650
+  testing.runTests.func1()
+      /usr/local/go/src/testing/testing.go:1119 +0xa8
+  testing.tRunner()
+      /usr/local/go/src/testing/testing.go:827 +0x162
+  testing.runTests()
+      /usr/local/go/src/testing/testing.go:1117 +0x4ee
+  testing.(*M).Run()
+      /usr/local/go/src/testing/testing.go:1034 +0x2ee
+  main.main()
+      _testmain.go:42 +0x221

--- a/parse/testdata/race/input01.json
+++ b/parse/testdata/race/input01.json
@@ -1,0 +1,53 @@
+{"Time":"2018-12-16T20:28:29.256021-05:00","Action":"run","Package":"command-line-arguments","Test":"TestRace1"}
+{"Time":"2018-12-16T20:28:29.256317-05:00","Action":"output","Package":"command-line-arguments","Test":"TestRace1","Output":"=== RUN   TestRace1\n"}
+{"Time":"2018-12-16T20:28:29.256347-05:00","Action":"output","Package":"command-line-arguments","Test":"TestRace1","Output":"=== PAUSE TestRace1\n"}
+{"Time":"2018-12-16T20:28:29.256355-05:00","Action":"pause","Package":"command-line-arguments","Test":"TestRace1"}
+{"Time":"2018-12-16T20:28:29.256363-05:00","Action":"run","Package":"command-line-arguments","Test":"TestA"}
+{"Time":"2018-12-16T20:28:29.25637-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"=== RUN   TestA\n"}
+{"Time":"2018-12-16T20:28:29.256377-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"=== PAUSE TestA\n"}
+{"Time":"2018-12-16T20:28:29.256384-05:00","Action":"pause","Package":"command-line-arguments","Test":"TestA"}
+{"Time":"2018-12-16T20:28:29.256538-05:00","Action":"cont","Package":"command-line-arguments","Test":"TestA"}
+{"Time":"2018-12-16T20:28:29.256559-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"=== CONT  TestA\n"}
+{"Time":"2018-12-16T20:28:29.256572-05:00","Action":"cont","Package":"command-line-arguments","Test":"TestRace1"}
+{"Time":"2018-12-16T20:28:29.256579-05:00","Action":"output","Package":"command-line-arguments","Test":"TestRace1","Output":"=== CONT  TestRace1\n"}
+{"Time":"2018-12-16T20:28:29.256742-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"--- PASS: TestA (0.00s)\n"}
+{"Time":"2018-12-16T20:28:29.256827-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"==================\n"}
+{"Time":"2018-12-16T20:28:29.256859-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"WARNING: DATA RACE\n"}
+{"Time":"2018-12-16T20:28:29.256868-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"Write at 0x00c0000be010 by goroutine 9:\n"}
+{"Time":"2018-12-16T20:28:29.25689-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"  command-line-arguments.TestRace1.func1()\n"}
+{"Time":"2018-12-16T20:28:29.256899-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"      /Users/michael.fridman/go/src/debug/tparse-24/some_test.go:8 +0x38\n"}
+{"Time":"2018-12-16T20:28:29.256915-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"\n"}
+{"Time":"2018-12-16T20:28:29.256929-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"Previous write at 0x00c0000be010 by goroutine 6:\n"}
+{"Time":"2018-12-16T20:28:29.256936-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"  command-line-arguments.TestRace1()\n"}
+{"Time":"2018-12-16T20:28:29.256942-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"      /Users/michael.fridman/go/src/debug/tparse-24/some_test.go:9 +0x96\n"}
+{"Time":"2018-12-16T20:28:29.256948-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"  testing.tRunner()\n"}
+{"Time":"2018-12-16T20:28:29.256961-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"      /usr/local/go/src/testing/testing.go:827 +0x162\n"}
+{"Time":"2018-12-16T20:28:29.256968-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"\n"}
+{"Time":"2018-12-16T20:28:29.256974-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"Goroutine 9 (running) created at:\n"}
+{"Time":"2018-12-16T20:28:29.25698-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"  command-line-arguments.TestRace1()\n"}
+{"Time":"2018-12-16T20:28:29.256986-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"      /Users/michael.fridman/go/src/debug/tparse-24/some_test.go:8 +0x88\n"}
+{"Time":"2018-12-16T20:28:29.256993-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"  testing.tRunner()\n"}
+{"Time":"2018-12-16T20:28:29.257034-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"      /usr/local/go/src/testing/testing.go:827 +0x162\n"}
+{"Time":"2018-12-16T20:28:29.257044-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"\n"}
+{"Time":"2018-12-16T20:28:29.257097-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"Goroutine 6 (running) created at:\n"}
+{"Time":"2018-12-16T20:28:29.257111-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"  testing.(*T).Run()\n"}
+{"Time":"2018-12-16T20:28:29.257121-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"      /usr/local/go/src/testing/testing.go:878 +0x650\n"}
+{"Time":"2018-12-16T20:28:29.257127-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"  testing.runTests.func1()\n"}
+{"Time":"2018-12-16T20:28:29.257134-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"      /usr/local/go/src/testing/testing.go:1119 +0xa8\n"}
+{"Time":"2018-12-16T20:28:29.25714-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"  testing.tRunner()\n"}
+{"Time":"2018-12-16T20:28:29.257146-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"      /usr/local/go/src/testing/testing.go:827 +0x162\n"}
+{"Time":"2018-12-16T20:28:29.257153-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"  testing.runTests()\n"}
+{"Time":"2018-12-16T20:28:29.257162-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"      /usr/local/go/src/testing/testing.go:1117 +0x4ee\n"}
+{"Time":"2018-12-16T20:28:29.25717-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"  testing.(*M).Run()\n"}
+{"Time":"2018-12-16T20:28:29.257187-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"      /usr/local/go/src/testing/testing.go:1034 +0x2ee\n"}
+{"Time":"2018-12-16T20:28:29.257196-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"  main.main()\n"}
+{"Time":"2018-12-16T20:28:29.257209-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"      _testmain.go:44 +0x221\n"}
+{"Time":"2018-12-16T20:28:29.257216-05:00","Action":"output","Package":"command-line-arguments","Test":"TestA","Output":"==================\n"}
+{"Time":"2018-12-16T20:28:29.257467-05:00","Action":"pass","Package":"command-line-arguments","Test":"TestA","Elapsed":0}
+{"Time":"2018-12-16T20:28:29.257487-05:00","Action":"output","Package":"command-line-arguments","Test":"TestRace1","Output":"--- FAIL: TestRace1 (0.00s)\n"}
+{"Time":"2018-12-16T20:28:29.257498-05:00","Action":"output","Package":"command-line-arguments","Test":"TestRace1","Output":"    some_test.go:10: 64\n"}
+{"Time":"2018-12-16T20:28:29.257508-05:00","Action":"output","Package":"command-line-arguments","Test":"TestRace1","Output":"    testing.go:771: race detected during execution of test\n"}
+{"Time":"2018-12-16T20:28:29.257518-05:00","Action":"fail","Package":"command-line-arguments","Test":"TestRace1","Elapsed":0}
+{"Time":"2018-12-16T20:28:29.257524-05:00","Action":"output","Package":"command-line-arguments","Output":"FAIL\n"}
+{"Time":"2018-12-16T20:28:29.258518-05:00","Action":"output","Package":"command-line-arguments","Output":"FAIL\tcommand-line-arguments\t0.016s\n"}
+{"Time":"2018-12-16T20:28:29.258549-05:00","Action":"fail","Package":"command-line-arguments","Elapsed":0.017}

--- a/parse/testdata/race/input02.json
+++ b/parse/testdata/race/input02.json
@@ -1,0 +1,631 @@
+{"Time":"2018-12-16T21:03:39.624243-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome"}
+{"Time":"2018-12-16T21:03:39.62455-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome","Output":"=== RUN   TestBigOutcome\n"}
+{"Time":"2018-12-16T21:03:39.624583-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome","Output":"=== PAUSE TestBigOutcome\n"}
+{"Time":"2018-12-16T21:03:39.624592-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome"}
+{"Time":"2018-12-16T21:03:39.624602-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent"}
+{"Time":"2018-12-16T21:03:39.624607-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent","Output":"=== RUN   TestNewEvent\n"}
+{"Time":"2018-12-16T21:03:39.624617-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent","Output":"=== PAUSE TestNewEvent\n"}
+{"Time":"2018-12-16T21:03:39.624622-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent"}
+{"Time":"2018-12-16T21:03:39.624628-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent"}
+{"Time":"2018-12-16T21:03:39.624639-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent","Output":"=== RUN   TestCachedEvent\n"}
+{"Time":"2018-12-16T21:03:39.624883-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent","Output":"=== PAUSE TestCachedEvent\n"}
+{"Time":"2018-12-16T21:03:39.624899-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent"}
+{"Time":"2018-12-16T21:03:39.624937-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent"}
+{"Time":"2018-12-16T21:03:39.624946-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent","Output":"=== RUN   TestCoverEvent\n"}
+{"Time":"2018-12-16T21:03:39.625109-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent","Output":"=== PAUSE TestCoverEvent\n"}
+{"Time":"2018-12-16T21:03:39.62512-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent"}
+{"Time":"2018-12-16T21:03:39.625129-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles"}
+{"Time":"2018-12-16T21:03:39.625135-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles","Output":"=== RUN   TestNoTestFiles\n"}
+{"Time":"2018-12-16T21:03:39.625295-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles","Output":"=== PAUSE TestNoTestFiles\n"}
+{"Time":"2018-12-16T21:03:39.625305-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles"}
+{"Time":"2018-12-16T21:03:39.625324-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun"}
+{"Time":"2018-12-16T21:03:39.625332-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun","Output":"=== RUN   TestNoTestsToRun\n"}
+{"Time":"2018-12-16T21:03:39.625478-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun","Output":"=== PAUSE TestNoTestsToRun\n"}
+{"Time":"2018-12-16T21:03:39.625501-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun"}
+{"Time":"2018-12-16T21:03:39.625516-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn"}
+{"Time":"2018-12-16T21:03:39.625527-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn","Output":"=== RUN   TestNoTestsWarn\n"}
+{"Time":"2018-12-16T21:03:39.625665-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn","Output":"=== PAUSE TestNoTestsWarn\n"}
+{"Time":"2018-12-16T21:03:39.625689-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn"}
+{"Time":"2018-12-16T21:03:39.6257-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestActionString"}
+{"Time":"2018-12-16T21:03:39.625706-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestActionString","Output":"=== RUN   TestActionString\n"}
+{"Time":"2018-12-16T21:03:39.625847-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestActionString","Output":"=== PAUSE TestActionString\n"}
+{"Time":"2018-12-16T21:03:39.625858-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestActionString"}
+{"Time":"2018-12-16T21:03:39.625871-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache"}
+{"Time":"2018-12-16T21:03:39.625877-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache","Output":"=== RUN   TestPackageCache\n"}
+{"Time":"2018-12-16T21:03:39.626027-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache","Output":"=== PAUSE TestPackageCache\n"}
+{"Time":"2018-12-16T21:03:39.626038-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache"}
+{"Time":"2018-12-16T21:03:39.626047-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover"}
+{"Time":"2018-12-16T21:03:39.626053-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover","Output":"=== RUN   TestPackageCover\n"}
+{"Time":"2018-12-16T21:03:39.626233-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover","Output":"=== PAUSE TestPackageCover\n"}
+{"Time":"2018-12-16T21:03:39.626244-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover"}
+{"Time":"2018-12-16T21:03:39.626256-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics"}
+{"Time":"2018-12-16T21:03:39.626266-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics","Output":"=== RUN   TestMetrics\n"}
+{"Time":"2018-12-16T21:03:39.626433-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics","Output":"=== PAUSE TestMetrics\n"}
+{"Time":"2018-12-16T21:03:39.626443-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics"}
+{"Time":"2018-12-16T21:03:39.626454-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed"}
+{"Time":"2018-12-16T21:03:39.62646-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"=== RUN   TestElapsed\n"}
+{"Time":"2018-12-16T21:03:39.626688-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"=== PAUSE TestElapsed\n"}
+{"Time":"2018-12-16T21:03:39.626715-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed"}
+{"Time":"2018-12-16T21:03:39.626771-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic"}
+{"Time":"2018-12-16T21:03:39.626779-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic","Output":"=== RUN   TestPanic\n"}
+{"Time":"2018-12-16T21:03:39.626907-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic","Output":"=== PAUSE TestPanic\n"}
+{"Time":"2018-12-16T21:03:39.626918-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic"}
+{"Time":"2018-12-16T21:03:39.627043-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan"}
+{"Time":"2018-12-16T21:03:39.627055-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan","Output":"=== RUN   TestPrescan\n"}
+{"Time":"2018-12-16T21:03:39.627217-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan","Output":"=== PAUSE TestPrescan\n"}
+{"Time":"2018-12-16T21:03:39.627235-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan"}
+{"Time":"2018-12-16T21:03:39.62725-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestRaceReplay"}
+{"Time":"2018-12-16T21:03:39.627257-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRaceReplay","Output":"=== RUN   TestRaceReplay\n"}
+{"Time":"2018-12-16T21:03:39.627805-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestRaceReplay/input01"}
+{"Time":"2018-12-16T21:03:39.627822-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRaceReplay/input01","Output":"=== RUN   TestRaceReplay/input01\n"}
+{"Time":"2018-12-16T21:03:39.637554-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRaceReplay","Output":"--- PASS: TestRaceReplay (0.01s)\n"}
+{"Time":"2018-12-16T21:03:39.637605-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRaceReplay/input01","Output":"    --- PASS: TestRaceReplay/input01 (0.01s)\n"}
+{"Time":"2018-12-16T21:03:39.63762-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestRaceReplay/input01","Elapsed":0.01}
+{"Time":"2018-12-16T21:03:39.637642-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestRaceReplay","Elapsed":0.01}
+{"Time":"2018-12-16T21:03:39.637649-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestReplay"}
+{"Time":"2018-12-16T21:03:39.637657-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestReplay","Output":"=== RUN   TestReplay\n"}
+{"Time":"2018-12-16T21:03:39.637824-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestReplay/input01"}
+{"Time":"2018-12-16T21:03:39.637836-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestReplay/input01","Output":"=== RUN   TestReplay/input01\n"}
+{"Time":"2018-12-16T21:03:39.641413-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestReplay/input02"}
+{"Time":"2018-12-16T21:03:39.641461-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestReplay/input02","Output":"=== RUN   TestReplay/input02\n"}
+{"Time":"2018-12-16T21:03:39.648192-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestReplay","Output":"--- PASS: TestReplay (0.01s)\n"}
+{"Time":"2018-12-16T21:03:39.648214-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestReplay/input01","Output":"    --- PASS: TestReplay/input01 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.648231-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestReplay/input01","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.64824-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestReplay/input02","Output":"    --- PASS: TestReplay/input02 (0.01s)\n"}
+{"Time":"2018-12-16T21:03:39.648265-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestReplay/input02","Elapsed":0.01}
+{"Time":"2018-12-16T21:03:39.648274-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestReplay","Elapsed":0.01}
+{"Time":"2018-12-16T21:03:39.64828-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestRace1"}
+{"Time":"2018-12-16T21:03:39.648285-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRace1","Output":"=== RUN   TestRace1\n"}
+{"Time":"2018-12-16T21:03:39.648555-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRace1","Output":"=== PAUSE TestRace1\n"}
+{"Time":"2018-12-16T21:03:39.648576-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestRace1"}
+{"Time":"2018-12-16T21:03:39.648584-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestRace2"}
+{"Time":"2018-12-16T21:03:39.648594-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRace2","Output":"=== RUN   TestRace2\n"}
+{"Time":"2018-12-16T21:03:39.648608-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRace2","Output":"=== PAUSE TestRace2\n"}
+{"Time":"2018-12-16T21:03:39.648614-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestRace2"}
+{"Time":"2018-12-16T21:03:39.649182-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestA"}
+{"Time":"2018-12-16T21:03:39.649204-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestA","Output":"=== RUN   TestA\n"}
+{"Time":"2018-12-16T21:03:39.649328-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestA","Output":"=== PAUSE TestA\n"}
+{"Time":"2018-12-16T21:03:39.649344-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestA"}
+{"Time":"2018-12-16T21:03:39.649354-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestB"}
+{"Time":"2018-12-16T21:03:39.649361-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"=== RUN   TestB\n"}
+{"Time":"2018-12-16T21:03:39.649566-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"=== PAUSE TestB\n"}
+{"Time":"2018-12-16T21:03:39.649577-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestB"}
+{"Time":"2018-12-16T21:03:39.649584-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack"}
+{"Time":"2018-12-16T21:03:39.64959-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack","Output":"=== RUN   TestSingleFailStack\n"}
+{"Time":"2018-12-16T21:03:39.649761-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack","Output":"=== PAUSE TestSingleFailStack\n"}
+{"Time":"2018-12-16T21:03:39.64978-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack"}
+{"Time":"2018-12-16T21:03:39.650359-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent"}
+{"Time":"2018-12-16T21:03:39.650372-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent","Output":"=== CONT  TestNewEvent\n"}
+{"Time":"2018-12-16T21:03:39.650379-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover"}
+{"Time":"2018-12-16T21:03:39.650385-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover","Output":"=== CONT  TestPackageCover\n"}
+{"Time":"2018-12-16T21:03:39.650392-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache"}
+{"Time":"2018-12-16T21:03:39.650397-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache","Output":"=== CONT  TestPackageCache\n"}
+{"Time":"2018-12-16T21:03:39.651975-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun"}
+{"Time":"2018-12-16T21:03:39.652929-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun","Output":"=== CONT  TestNoTestsToRun\n"}
+{"Time":"2018-12-16T21:03:39.652946-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun/event_0"}
+{"Time":"2018-12-16T21:03:39.652954-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun/event_0","Output":"=== RUN   TestNoTestsToRun/event_0\n"}
+{"Time":"2018-12-16T21:03:39.652965-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun/event_1"}
+{"Time":"2018-12-16T21:03:39.652971-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun/event_1","Output":"=== RUN   TestNoTestsToRun/event_1\n"}
+{"Time":"2018-12-16T21:03:39.652978-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun/event_2"}
+{"Time":"2018-12-16T21:03:39.652983-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun/event_2","Output":"=== RUN   TestNoTestsToRun/event_2\n"}
+{"Time":"2018-12-16T21:03:39.65299-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_0"}
+{"Time":"2018-12-16T21:03:39.653-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_0","Output":"=== RUN   TestNewEvent/event_0\n"}
+{"Time":"2018-12-16T21:03:39.653007-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun/event_3"}
+{"Time":"2018-12-16T21:03:39.653013-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun/event_3","Output":"=== RUN   TestNoTestsToRun/event_3\n"}
+{"Time":"2018-12-16T21:03:39.653021-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_0","Output":"=== PAUSE TestNewEvent/event_0\n"}
+{"Time":"2018-12-16T21:03:39.653028-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_0"}
+{"Time":"2018-12-16T21:03:39.653035-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_1"}
+{"Time":"2018-12-16T21:03:39.653041-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_1","Output":"=== RUN   TestNewEvent/event_1\n"}
+{"Time":"2018-12-16T21:03:39.653052-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_1","Output":"=== PAUSE TestNewEvent/event_1\n"}
+{"Time":"2018-12-16T21:03:39.653058-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_1"}
+{"Time":"2018-12-16T21:03:39.653064-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_2"}
+{"Time":"2018-12-16T21:03:39.65307-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_2","Output":"=== RUN   TestNewEvent/event_2\n"}
+{"Time":"2018-12-16T21:03:39.653079-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun","Output":"--- PASS: TestNoTestsToRun (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.653087-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun/event_0","Output":"    --- PASS: TestNoTestsToRun/event_0 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.653094-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun/event_0","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.653102-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun/event_1","Output":"    --- PASS: TestNoTestsToRun/event_1 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.653108-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun/event_1","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.653114-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun/event_2","Output":"    --- PASS: TestNoTestsToRun/event_2 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.653122-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun/event_2","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.653129-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun/event_3","Output":"    --- PASS: TestNoTestsToRun/event_3 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.653136-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun/event_3","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.653142-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsToRun","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.653148-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan"}
+{"Time":"2018-12-16T21:03:39.653154-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan","Output":"=== CONT  TestPrescan\n"}
+{"Time":"2018-12-16T21:03:39.653163-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input01.txt"}
+{"Time":"2018-12-16T21:03:39.653169-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input01.txt","Output":"=== RUN   TestPrescan/input01.txt\n"}
+{"Time":"2018-12-16T21:03:39.653177-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_2","Output":"=== PAUSE TestNewEvent/event_2\n"}
+{"Time":"2018-12-16T21:03:39.653183-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_2"}
+{"Time":"2018-12-16T21:03:39.653189-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_3"}
+{"Time":"2018-12-16T21:03:39.653198-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_3","Output":"=== RUN   TestNewEvent/event_3\n"}
+{"Time":"2018-12-16T21:03:39.653205-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input01.txt","Output":"=== PAUSE TestPrescan/input01.txt\n"}
+{"Time":"2018-12-16T21:03:39.653211-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input01.txt"}
+{"Time":"2018-12-16T21:03:39.653217-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input02.txt"}
+{"Time":"2018-12-16T21:03:39.653226-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input02.txt","Output":"=== RUN   TestPrescan/input02.txt\n"}
+{"Time":"2018-12-16T21:03:39.653232-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_3","Output":"=== PAUSE TestNewEvent/event_3\n"}
+{"Time":"2018-12-16T21:03:39.653238-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_3"}
+{"Time":"2018-12-16T21:03:39.653246-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_4"}
+{"Time":"2018-12-16T21:03:39.653252-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_4","Output":"=== RUN   TestNewEvent/event_4\n"}
+{"Time":"2018-12-16T21:03:39.653259-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input02.txt","Output":"=== PAUSE TestPrescan/input02.txt\n"}
+{"Time":"2018-12-16T21:03:39.653265-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input02.txt"}
+{"Time":"2018-12-16T21:03:39.653271-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input03.txt"}
+{"Time":"2018-12-16T21:03:39.653277-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input03.txt","Output":"=== RUN   TestPrescan/input03.txt\n"}
+{"Time":"2018-12-16T21:03:39.653284-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_4","Output":"=== PAUSE TestNewEvent/event_4\n"}
+{"Time":"2018-12-16T21:03:39.653449-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_4"}
+{"Time":"2018-12-16T21:03:39.653458-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_5"}
+{"Time":"2018-12-16T21:03:39.653464-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_5","Output":"=== RUN   TestNewEvent/event_5\n"}
+{"Time":"2018-12-16T21:03:39.653474-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input03.txt","Output":"=== PAUSE TestPrescan/input03.txt\n"}
+{"Time":"2018-12-16T21:03:39.65348-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input03.txt"}
+{"Time":"2018-12-16T21:03:39.653487-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input04.txt"}
+{"Time":"2018-12-16T21:03:39.653493-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input04.txt","Output":"=== RUN   TestPrescan/input04.txt\n"}
+{"Time":"2018-12-16T21:03:39.6535-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_5","Output":"=== PAUSE TestNewEvent/event_5\n"}
+{"Time":"2018-12-16T21:03:39.653506-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_5"}
+{"Time":"2018-12-16T21:03:39.653513-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input04.txt","Output":"=== PAUSE TestPrescan/input04.txt\n"}
+{"Time":"2018-12-16T21:03:39.653518-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input04.txt"}
+{"Time":"2018-12-16T21:03:39.653525-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_6"}
+{"Time":"2018-12-16T21:03:39.653531-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_6","Output":"=== RUN   TestNewEvent/event_6\n"}
+{"Time":"2018-12-16T21:03:39.653547-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_6","Output":"=== PAUSE TestNewEvent/event_6\n"}
+{"Time":"2018-12-16T21:03:39.653554-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_6"}
+{"Time":"2018-12-16T21:03:39.65356-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn"}
+{"Time":"2018-12-16T21:03:39.653568-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn","Output":"=== CONT  TestNoTestsWarn\n"}
+{"Time":"2018-12-16T21:03:39.653575-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn/event_0"}
+{"Time":"2018-12-16T21:03:39.653584-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn/event_0","Output":"=== RUN   TestNoTestsWarn/event_0\n"}
+{"Time":"2018-12-16T21:03:39.65359-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn/event_1"}
+{"Time":"2018-12-16T21:03:39.653598-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn/event_1","Output":"=== RUN   TestNoTestsWarn/event_1\n"}
+{"Time":"2018-12-16T21:03:39.65441-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn/event_2"}
+{"Time":"2018-12-16T21:03:39.654422-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn/event_2","Output":"=== RUN   TestNoTestsWarn/event_2\n"}
+{"Time":"2018-12-16T21:03:39.654429-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_7"}
+{"Time":"2018-12-16T21:03:39.654435-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_7","Output":"=== RUN   TestNewEvent/event_7\n"}
+{"Time":"2018-12-16T21:03:39.654441-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn/event_3"}
+{"Time":"2018-12-16T21:03:39.654447-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn/event_3","Output":"=== RUN   TestNoTestsWarn/event_3\n"}
+{"Time":"2018-12-16T21:03:39.654453-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_7","Output":"=== PAUSE TestNewEvent/event_7\n"}
+{"Time":"2018-12-16T21:03:39.654459-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_7"}
+{"Time":"2018-12-16T21:03:39.654466-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_8"}
+{"Time":"2018-12-16T21:03:39.654473-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_8","Output":"=== RUN   TestNewEvent/event_8\n"}
+{"Time":"2018-12-16T21:03:39.654479-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_8","Output":"=== PAUSE TestNewEvent/event_8\n"}
+{"Time":"2018-12-16T21:03:39.654484-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_8"}
+{"Time":"2018-12-16T21:03:39.654489-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_9"}
+{"Time":"2018-12-16T21:03:39.654494-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_9","Output":"=== RUN   TestNewEvent/event_9\n"}
+{"Time":"2018-12-16T21:03:39.655057-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn","Output":"--- PASS: TestNoTestsWarn (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.655086-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn/event_0","Output":"    --- PASS: TestNoTestsWarn/event_0 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.655094-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn/event_0","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.655101-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn/event_1","Output":"    --- PASS: TestNoTestsWarn/event_1 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.655108-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn/event_1","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.655114-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn/event_2","Output":"    --- PASS: TestNoTestsWarn/event_2 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.655121-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn/event_2","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.655127-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn/event_3","Output":"    --- PASS: TestNoTestsWarn/event_3 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.655134-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn/event_3","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.655138-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestsWarn","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.655143-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestActionString"}
+{"Time":"2018-12-16T21:03:39.655148-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestActionString","Output":"=== CONT  TestActionString\n"}
+{"Time":"2018-12-16T21:03:39.655154-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestActionString","Output":"--- PASS: TestActionString (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.655161-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestActionString","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.655167-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_9","Output":"=== PAUSE TestNewEvent/event_9\n"}
+{"Time":"2018-12-16T21:03:39.655183-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_9"}
+{"Time":"2018-12-16T21:03:39.65519-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles"}
+{"Time":"2018-12-16T21:03:39.6552-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles","Output":"=== CONT  TestNoTestFiles\n"}
+{"Time":"2018-12-16T21:03:39.655208-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles/event_0"}
+{"Time":"2018-12-16T21:03:39.655214-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles/event_0","Output":"=== RUN   TestNoTestFiles/event_0\n"}
+{"Time":"2018-12-16T21:03:39.65522-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent"}
+{"Time":"2018-12-16T21:03:39.655233-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent","Output":"=== CONT  TestCoverEvent\n"}
+{"Time":"2018-12-16T21:03:39.655246-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_0"}
+{"Time":"2018-12-16T21:03:39.655252-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_0","Output":"=== RUN   TestCoverEvent/event_0\n"}
+{"Time":"2018-12-16T21:03:39.65583-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles/event_1"}
+{"Time":"2018-12-16T21:03:39.655842-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles/event_1","Output":"=== RUN   TestNoTestFiles/event_1\n"}
+{"Time":"2018-12-16T21:03:39.655851-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_1"}
+{"Time":"2018-12-16T21:03:39.655867-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_1","Output":"=== RUN   TestCoverEvent/event_1\n"}
+{"Time":"2018-12-16T21:03:39.655877-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles/event_2"}
+{"Time":"2018-12-16T21:03:39.655882-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles/event_2","Output":"=== RUN   TestNoTestFiles/event_2\n"}
+{"Time":"2018-12-16T21:03:39.656487-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_2"}
+{"Time":"2018-12-16T21:03:39.656499-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_2","Output":"=== RUN   TestCoverEvent/event_2\n"}
+{"Time":"2018-12-16T21:03:39.657979-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_3"}
+{"Time":"2018-12-16T21:03:39.658021-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_3","Output":"=== RUN   TestCoverEvent/event_3\n"}
+{"Time":"2018-12-16T21:03:39.658031-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_4"}
+{"Time":"2018-12-16T21:03:39.658037-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_4","Output":"=== RUN   TestCoverEvent/event_4\n"}
+{"Time":"2018-12-16T21:03:39.659083-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles/event_3"}
+{"Time":"2018-12-16T21:03:39.659098-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles/event_3","Output":"=== RUN   TestNoTestFiles/event_3\n"}
+{"Time":"2018-12-16T21:03:39.659109-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles","Output":"--- PASS: TestNoTestFiles (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.659117-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles/event_0","Output":"    --- PASS: TestNoTestFiles/event_0 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.659124-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles/event_0","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.659132-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles/event_1","Output":"    --- PASS: TestNoTestFiles/event_1 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.659139-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles/event_1","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.659145-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles/event_2","Output":"    --- PASS: TestNoTestFiles/event_2 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.659151-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles/event_2","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.659157-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles/event_3","Output":"    --- PASS: TestNoTestFiles/event_3 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.659163-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles/event_3","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.659169-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNoTestFiles","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.659174-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_5"}
+{"Time":"2018-12-16T21:03:39.659179-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_5","Output":"=== RUN   TestCoverEvent/event_5\n"}
+{"Time":"2018-12-16T21:03:39.659186-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestRace1"}
+{"Time":"2018-12-16T21:03:39.659192-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRace1","Output":"=== CONT  TestRace1\n"}
+{"Time":"2018-12-16T21:03:39.659198-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRace1","Output":"--- PASS: TestRace1 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.659204-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRace1","Output":"    some_test.go:12: 64\n"}
+{"Time":"2018-12-16T21:03:39.659211-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestRace1","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.659216-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack"}
+{"Time":"2018-12-16T21:03:39.659233-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack","Output":"=== CONT  TestSingleFailStack\n"}
+{"Time":"2018-12-16T21:03:39.65924-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01"}
+{"Time":"2018-12-16T21:03:39.659245-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"=== RUN   TestSingleFailStack/input01\n"}
+{"Time":"2018-12-16T21:03:39.661393-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent","Output":"--- PASS: TestCoverEvent (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.661458-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_0","Output":"    --- PASS: TestCoverEvent/event_0 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.661471-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_0","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.661479-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_1","Output":"    --- PASS: TestCoverEvent/event_1 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.661487-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_1","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.661508-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_2","Output":"    --- PASS: TestCoverEvent/event_2 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.661517-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_2","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.661523-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_3","Output":"    --- PASS: TestCoverEvent/event_3 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.661529-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_3","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.661535-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_4","Output":"    --- PASS: TestCoverEvent/event_4 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.661545-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_4","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.661551-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_5","Output":"    --- PASS: TestCoverEvent/event_5 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.661558-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent/event_5","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.661564-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestCoverEvent","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.66157-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestA"}
+{"Time":"2018-12-16T21:03:39.661576-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestA","Output":"=== CONT  TestA\n"}
+{"Time":"2018-12-16T21:03:39.661583-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestA","Output":"--- PASS: TestA (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.661622-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestA","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.661634-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestRace2"}
+{"Time":"2018-12-16T21:03:39.66164-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRace2","Output":"=== CONT  TestRace2\n"}
+{"Time":"2018-12-16T21:03:39.661649-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRace2","Output":"--- PASS: TestRace2 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.661656-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRace2","Output":"    some_test.go:19: 64\n"}
+{"Time":"2018-12-16T21:03:39.661662-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRace2","Output":"    some_test.go:21: 64\n"}
+{"Time":"2018-12-16T21:03:39.661679-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRace2","Output":"    some_test.go:24: 64\n"}
+{"Time":"2018-12-16T21:03:39.66169-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestRace2","Output":"    some_test.go:27: 64\n"}
+{"Time":"2018-12-16T21:03:39.661698-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestRace2","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.661704-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestB"}
+{"Time":"2018-12-16T21:03:39.661736-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"=== CONT  TestB\n"}
+{"Time":"2018-12-16T21:03:39.661747-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"--- PASS: TestB (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.661754-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"==================\n"}
+{"Time":"2018-12-16T21:03:39.66176-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"WARNING: DATA RACE\n"}
+{"Time":"2018-12-16T21:03:39.661766-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"Write at 0x00c0000d8938 by goroutine 65:\n"}
+{"Time":"2018-12-16T21:03:39.661772-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"  github.com/mfridman/tparse/parse.TestRace2.func1()\n"}
+{"Time":"2018-12-16T21:03:39.661778-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"      /Users/michael.fridman/go/src/github.com/mfridman/tparse/parse/some_test.go:17 +0x38\n"}
+{"Time":"2018-12-16T21:03:39.661793-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"\n"}
+{"Time":"2018-12-16T21:03:39.6618-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"Previous write at 0x00c0000d8938 by goroutine 26:\n"}
+{"Time":"2018-12-16T21:03:39.66181-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"  github.com/mfridman/tparse/parse.TestRace2()\n"}
+{"Time":"2018-12-16T21:03:39.661826-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"      /Users/michael.fridman/go/src/github.com/mfridman/tparse/parse/some_test.go:18 +0x96\n"}
+{"Time":"2018-12-16T21:03:39.661833-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"  testing.tRunner()\n"}
+{"Time":"2018-12-16T21:03:39.661839-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"      /usr/local/go/src/testing/testing.go:827 +0x162\n"}
+{"Time":"2018-12-16T21:03:39.661845-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"\n"}
+{"Time":"2018-12-16T21:03:39.661851-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"Goroutine 65 (running) created at:\n"}
+{"Time":"2018-12-16T21:03:39.661857-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"  github.com/mfridman/tparse/parse.TestRace2()\n"}
+{"Time":"2018-12-16T21:03:39.661864-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"      /Users/michael.fridman/go/src/github.com/mfridman/tparse/parse/some_test.go:17 +0x88\n"}
+{"Time":"2018-12-16T21:03:39.66187-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"  testing.tRunner()\n"}
+{"Time":"2018-12-16T21:03:39.661876-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"      /usr/local/go/src/testing/testing.go:827 +0x162\n"}
+{"Time":"2018-12-16T21:03:39.661882-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"\n"}
+{"Time":"2018-12-16T21:03:39.661888-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"Goroutine 26 (running) created at:\n"}
+{"Time":"2018-12-16T21:03:39.661894-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"  testing.(*T).Run()\n"}
+{"Time":"2018-12-16T21:03:39.661901-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"      /usr/local/go/src/testing/testing.go:878 +0x650\n"}
+{"Time":"2018-12-16T21:03:39.661907-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"  testing.runTests.func1()\n"}
+{"Time":"2018-12-16T21:03:39.661913-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"      /usr/local/go/src/testing/testing.go:1119 +0xa8\n"}
+{"Time":"2018-12-16T21:03:39.661919-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"  testing.tRunner()\n"}
+{"Time":"2018-12-16T21:03:39.661925-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"      /usr/local/go/src/testing/testing.go:827 +0x162\n"}
+{"Time":"2018-12-16T21:03:39.661931-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"  testing.runTests()\n"}
+{"Time":"2018-12-16T21:03:39.661937-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"      /usr/local/go/src/testing/testing.go:1117 +0x4ee\n"}
+{"Time":"2018-12-16T21:03:39.661943-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"  testing.(*M).Run()\n"}
+{"Time":"2018-12-16T21:03:39.662115-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"      /usr/local/go/src/testing/testing.go:1034 +0x2ee\n"}
+{"Time":"2018-12-16T21:03:39.662124-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"  main.main()\n"}
+{"Time":"2018-12-16T21:03:39.662131-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"      _testmain.go:136 +0x332\n"}
+{"Time":"2018-12-16T21:03:39.662137-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Output":"==================\n"}
+{"Time":"2018-12-16T21:03:39.662144-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestB","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.662151-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed"}
+{"Time":"2018-12-16T21:03:39.662157-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"=== CONT  TestElapsed\n"}
+{"Time":"2018-12-16T21:03:39.662492-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"==================\n"}
+{"Time":"2018-12-16T21:03:39.662504-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"WARNING: DATA RACE\n"}
+{"Time":"2018-12-16T21:03:39.662511-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"Write at 0x00c000014508 by goroutine 63:\n"}
+{"Time":"2018-12-16T21:03:39.662518-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"  github.com/mfridman/tparse/parse.TestRace1.func1()\n"}
+{"Time":"2018-12-16T21:03:39.662525-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"      /Users/michael.fridman/go/src/github.com/mfridman/tparse/parse/some_test.go:10 +0x38\n"}
+{"Time":"2018-12-16T21:03:39.662532-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"\n"}
+{"Time":"2018-12-16T21:03:39.662538-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"Previous write at 0x00c000014508 by goroutine 25:\n"}
+{"Time":"2018-12-16T21:03:39.662548-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"  github.com/mfridman/tparse/parse.TestRace1()\n"}
+{"Time":"2018-12-16T21:03:39.662555-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"      /Users/michael.fridman/go/src/github.com/mfridman/tparse/parse/some_test.go:11 +0x96\n"}
+{"Time":"2018-12-16T21:03:39.662562-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"  testing.tRunner()\n"}
+{"Time":"2018-12-16T21:03:39.662592-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"      /usr/local/go/src/testing/testing.go:827 +0x162\n"}
+{"Time":"2018-12-16T21:03:39.662608-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"\n"}
+{"Time":"2018-12-16T21:03:39.662622-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"Goroutine 63 (running) created at:\n"}
+{"Time":"2018-12-16T21:03:39.662638-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"  github.com/mfridman/tparse/parse.TestRace1()\n"}
+{"Time":"2018-12-16T21:03:39.662645-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"      /Users/michael.fridman/go/src/github.com/mfridman/tparse/parse/some_test.go:10 +0x88\n"}
+{"Time":"2018-12-16T21:03:39.662652-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"  testing.tRunner()\n"}
+{"Time":"2018-12-16T21:03:39.662668-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"      /usr/local/go/src/testing/testing.go:827 +0x162\n"}
+{"Time":"2018-12-16T21:03:39.662675-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"\n"}
+{"Time":"2018-12-16T21:03:39.662681-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"Goroutine 25 (running) created at:\n"}
+{"Time":"2018-12-16T21:03:39.662689-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"  testing.(*T).Run()\n"}
+{"Time":"2018-12-16T21:03:39.662696-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"      /usr/local/go/src/testing/testing.go:878 +0x650\n"}
+{"Time":"2018-12-16T21:03:39.662703-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"  testing.runTests.func1()\n"}
+{"Time":"2018-12-16T21:03:39.662712-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"      /usr/local/go/src/testing/testing.go:1119 +0xa8\n"}
+{"Time":"2018-12-16T21:03:39.662719-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"  testing.tRunner()\n"}
+{"Time":"2018-12-16T21:03:39.662725-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"      /usr/local/go/src/testing/testing.go:827 +0x162\n"}
+{"Time":"2018-12-16T21:03:39.662732-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"  testing.runTests()\n"}
+{"Time":"2018-12-16T21:03:39.662738-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"      /usr/local/go/src/testing/testing.go:1117 +0x4ee\n"}
+{"Time":"2018-12-16T21:03:39.662745-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"  testing.(*M).Run()\n"}
+{"Time":"2018-12-16T21:03:39.662751-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"      /usr/local/go/src/testing/testing.go:1034 +0x2ee\n"}
+{"Time":"2018-12-16T21:03:39.662758-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"  main.main()\n"}
+{"Time":"2018-12-16T21:03:39.662764-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"      _testmain.go:136 +0x332\n"}
+{"Time":"2018-12-16T21:03:39.66277-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"==================\n"}
+{"Time":"2018-12-16T21:03:39.66279-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input02"}
+{"Time":"2018-12-16T21:03:39.662798-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input02","Output":"=== RUN   TestSingleFailStack/input02\n"}
+{"Time":"2018-12-16T21:03:39.664004-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input03"}
+{"Time":"2018-12-16T21:03:39.664019-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input03","Output":"=== RUN   TestSingleFailStack/input03\n"}
+{"Time":"2018-12-16T21:03:39.665558-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input04"}
+{"Time":"2018-12-16T21:03:39.665576-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input04","Output":"=== RUN   TestSingleFailStack/input04\n"}
+{"Time":"2018-12-16T21:03:39.666788-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack","Output":"--- FAIL: TestSingleFailStack (0.01s)\n"}
+{"Time":"2018-12-16T21:03:39.666855-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"    --- FAIL: TestSingleFailStack/input01 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.666879-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"        stack_test.go:63: \n"}
+{"Time":"2018-12-16T21:03:39.666893-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"            got plain:\n"}
+{"Time":"2018-12-16T21:03:39.666908-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"            --- FAIL: TestStatus (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.666922-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"                status_test.go:91: got no failed tests, want one or more tests to be marked as \"fail\"\n"}
+{"Time":"2018-12-16T21:03:39.666937-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"            \n"}
+{"Time":"2018-12-16T21:03:39.666952-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"            got quoted:\n"}
+{"Time":"2018-12-16T21:03:39.666964-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"            \"--- FAIL: TestStatus (0.00s)\\n    status_test.go:91: got no failed tests, want one or more tests to be marked as \\\"fail\\\"\\n\"\n"}
+{"Time":"2018-12-16T21:03:39.666992-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"        stack_test.go:64: \n"}
+{"Time":"2018-12-16T21:03:39.667076-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"            want plain:\n"}
+{"Time":"2018-12-16T21:03:39.667105-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"            --- FAIL: TestStatus (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.667111-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"                status_test.go:91: got no failed tests, want one or more tests to be marked as \"fail\"\n"}
+{"Time":"2018-12-16T21:03:39.667123-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"            \n"}
+{"Time":"2018-12-16T21:03:39.667132-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"            want quoted:\n"}
+{"Time":"2018-12-16T21:03:39.667177-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"            \"--- FAIL: TestStatus (0.00s)\\n    status_test.go:91: got no failed tests, want one or more tests to be marked as \\\"fail\\\"\\n\"\n"}
+{"Time":"2018-12-16T21:03:39.667205-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Output":"        testing.go:771: race detected during execution of test\n"}
+{"Time":"2018-12-16T21:03:39.667238-05:00","Action":"fail","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input01","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.66726-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input02","Output":"    --- PASS: TestSingleFailStack/input02 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.667278-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input02","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.667294-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input03","Output":"    --- PASS: TestSingleFailStack/input03 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.667311-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input03","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.667324-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input04","Output":"    --- PASS: TestSingleFailStack/input04 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.667341-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input04","Output":"    testing.go:771: race detected during execution of test\n"}
+{"Time":"2018-12-16T21:03:39.667351-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack/input04","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.667365-05:00","Action":"fail","Package":"github.com/mfridman/tparse/parse","Test":"TestSingleFailStack","Elapsed":0.01}
+{"Time":"2018-12-16T21:03:39.66738-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic"}
+{"Time":"2018-12-16T21:03:39.6674-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic","Output":"=== CONT  TestPanic\n"}
+{"Time":"2018-12-16T21:03:39.667436-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input01.json"}
+{"Time":"2018-12-16T21:03:39.667457-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input01.json","Output":"=== RUN   TestPanic/input01.json\n"}
+{"Time":"2018-12-16T21:03:39.667477-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input01.json","Output":"=== PAUSE TestPanic/input01.json\n"}
+{"Time":"2018-12-16T21:03:39.667489-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input01.json"}
+{"Time":"2018-12-16T21:03:39.667502-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input02.json"}
+{"Time":"2018-12-16T21:03:39.667517-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input02.json","Output":"=== RUN   TestPanic/input02.json\n"}
+{"Time":"2018-12-16T21:03:39.667893-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input02.json","Output":"=== PAUSE TestPanic/input02.json\n"}
+{"Time":"2018-12-16T21:03:39.667943-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input02.json"}
+{"Time":"2018-12-16T21:03:39.668144-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input03.json"}
+{"Time":"2018-12-16T21:03:39.668262-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input03.json","Output":"=== RUN   TestPanic/input03.json\n"}
+{"Time":"2018-12-16T21:03:39.668644-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input03.json","Output":"=== PAUSE TestPanic/input03.json\n"}
+{"Time":"2018-12-16T21:03:39.668682-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input03.json"}
+{"Time":"2018-12-16T21:03:39.668711-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input04.json"}
+{"Time":"2018-12-16T21:03:39.668733-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input04.json","Output":"=== RUN   TestPanic/input04.json\n"}
+{"Time":"2018-12-16T21:03:39.669478-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input04.json","Output":"=== PAUSE TestPanic/input04.json\n"}
+{"Time":"2018-12-16T21:03:39.669545-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input04.json"}
+{"Time":"2018-12-16T21:03:39.669581-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input05.json"}
+{"Time":"2018-12-16T21:03:39.6696-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input05.json","Output":"=== RUN   TestPanic/input05.json\n"}
+{"Time":"2018-12-16T21:03:39.669617-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input05.json","Output":"=== PAUSE TestPanic/input05.json\n"}
+{"Time":"2018-12-16T21:03:39.669633-05:00","Action":"pause","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input05.json"}
+{"Time":"2018-12-16T21:03:39.669659-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics"}
+{"Time":"2018-12-16T21:03:39.669673-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics","Output":"=== CONT  TestMetrics\n"}
+{"Time":"2018-12-16T21:03:39.674025-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"--- FAIL: TestElapsed (0.01s)\n"}
+{"Time":"2018-12-16T21:03:39.674834-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"    metrics_test.go:155: expected test names:\n"}
+{"Time":"2018-12-16T21:03:39.674849-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"    metrics_test.go:157: TestCompareStrings\n"}
+{"Time":"2018-12-16T21:03:39.674857-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"    metrics_test.go:157: TestCaseConsistency\n"}
+{"Time":"2018-12-16T21:03:39.674863-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Output":"    testing.go:771: race detected during execution of test\n"}
+{"Time":"2018-12-16T21:03:39.674871-05:00","Action":"fail","Package":"github.com/mfridman/tparse/parse","Test":"TestElapsed","Elapsed":0.01}
+{"Time":"2018-12-16T21:03:39.67488-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent"}
+{"Time":"2018-12-16T21:03:39.674886-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent","Output":"=== CONT  TestCachedEvent\n"}
+{"Time":"2018-12-16T21:03:39.674893-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_0"}
+{"Time":"2018-12-16T21:03:39.674899-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_0","Output":"=== RUN   TestCachedEvent/event_0\n"}
+{"Time":"2018-12-16T21:03:39.674906-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_1"}
+{"Time":"2018-12-16T21:03:39.674924-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_1","Output":"=== RUN   TestCachedEvent/event_1\n"}
+{"Time":"2018-12-16T21:03:39.674931-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_2"}
+{"Time":"2018-12-16T21:03:39.674937-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_2","Output":"=== RUN   TestCachedEvent/event_2\n"}
+{"Time":"2018-12-16T21:03:39.674944-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_3"}
+{"Time":"2018-12-16T21:03:39.674949-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_3","Output":"=== RUN   TestCachedEvent/event_3\n"}
+{"Time":"2018-12-16T21:03:39.67496-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_4"}
+{"Time":"2018-12-16T21:03:39.674966-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_4","Output":"=== RUN   TestCachedEvent/event_4\n"}
+{"Time":"2018-12-16T21:03:39.674974-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent","Output":"--- PASS: TestCachedEvent (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.674981-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_0","Output":"    --- PASS: TestCachedEvent/event_0 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.674994-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_0","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.675001-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_1","Output":"    --- PASS: TestCachedEvent/event_1 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.675013-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_1","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.67502-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_2","Output":"    --- PASS: TestCachedEvent/event_2 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.675027-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_2","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.675033-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_3","Output":"    --- PASS: TestCachedEvent/event_3 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.67504-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_3","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.675046-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_4","Output":"    --- PASS: TestCachedEvent/event_4 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.675053-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent/event_4","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.675061-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestCachedEvent","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.675067-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome"}
+{"Time":"2018-12-16T21:03:39.675073-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome","Output":"=== CONT  TestBigOutcome\n"}
+{"Time":"2018-12-16T21:03:39.67508-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input01.json"}
+{"Time":"2018-12-16T21:03:39.675086-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input01.json","Output":"=== RUN   TestBigOutcome/input01.json\n"}
+{"Time":"2018-12-16T21:03:39.677177-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input02.json"}
+{"Time":"2018-12-16T21:03:39.677194-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input02.json","Output":"=== RUN   TestBigOutcome/input02.json\n"}
+{"Time":"2018-12-16T21:03:39.683956-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input03.json"}
+{"Time":"2018-12-16T21:03:39.683977-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input03.json","Output":"=== RUN   TestBigOutcome/input03.json\n"}
+{"Time":"2018-12-16T21:03:39.744943-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input04.json"}
+{"Time":"2018-12-16T21:03:39.744972-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input04.json","Output":"=== RUN   TestBigOutcome/input04.json\n"}
+{"Time":"2018-12-16T21:03:39.747908-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input05.json"}
+{"Time":"2018-12-16T21:03:39.747925-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input05.json","Output":"=== RUN   TestBigOutcome/input05.json\n"}
+{"Time":"2018-12-16T21:03:39.750109-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input06.json"}
+{"Time":"2018-12-16T21:03:39.750129-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input06.json","Output":"=== RUN   TestBigOutcome/input06.json\n"}
+{"Time":"2018-12-16T21:03:39.750959-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input07.json"}
+{"Time":"2018-12-16T21:03:39.750975-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input07.json","Output":"=== RUN   TestBigOutcome/input07.json\n"}
+{"Time":"2018-12-16T21:03:39.751577-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input08.json"}
+{"Time":"2018-12-16T21:03:39.75159-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input08.json","Output":"=== RUN   TestBigOutcome/input08.json\n"}
+{"Time":"2018-12-16T21:03:39.752271-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome","Output":"--- PASS: TestBigOutcome (0.08s)\n"}
+{"Time":"2018-12-16T21:03:39.752288-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input01.json","Output":"    --- PASS: TestBigOutcome/input01.json (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.752296-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input01.json","Output":"        big_test.go:60: input01.json 1\n"}
+{"Time":"2018-12-16T21:03:39.752311-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input01.json","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.752323-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input02.json","Output":"    --- PASS: TestBigOutcome/input02.json (0.01s)\n"}
+{"Time":"2018-12-16T21:03:39.752331-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input02.json","Output":"        big_test.go:60: input02.json 7\n"}
+{"Time":"2018-12-16T21:03:39.752339-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input02.json","Elapsed":0.01}
+{"Time":"2018-12-16T21:03:39.752354-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input03.json","Output":"    --- PASS: TestBigOutcome/input03.json (0.06s)\n"}
+{"Time":"2018-12-16T21:03:39.752367-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input03.json","Output":"        big_test.go:60: input03.json 1\n"}
+{"Time":"2018-12-16T21:03:39.752378-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input03.json","Elapsed":0.06}
+{"Time":"2018-12-16T21:03:39.752386-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input04.json","Output":"    --- PASS: TestBigOutcome/input04.json (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.752392-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input04.json","Output":"        big_test.go:60: input04.json 1\n"}
+{"Time":"2018-12-16T21:03:39.752404-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input04.json","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.752411-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input05.json","Output":"    --- PASS: TestBigOutcome/input05.json (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.752417-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input05.json","Output":"        big_test.go:60: input05.json 1\n"}
+{"Time":"2018-12-16T21:03:39.752425-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input05.json","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.752431-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input06.json","Output":"    --- PASS: TestBigOutcome/input06.json (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.752437-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input06.json","Output":"        big_test.go:60: input06.json 1\n"}
+{"Time":"2018-12-16T21:03:39.752444-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input06.json","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.75245-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input07.json","Output":"    --- PASS: TestBigOutcome/input07.json (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.752456-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input07.json","Output":"        big_test.go:60: input07.json 1\n"}
+{"Time":"2018-12-16T21:03:39.752463-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input07.json","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.752469-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input08.json","Output":"    --- PASS: TestBigOutcome/input08.json (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.752475-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input08.json","Output":"        big_test.go:60: input08.json 1\n"}
+{"Time":"2018-12-16T21:03:39.752485-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome/input08.json","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.752491-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestBigOutcome","Elapsed":0.08}
+{"Time":"2018-12-16T21:03:39.752497-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input01.txt"}
+{"Time":"2018-12-16T21:03:39.752503-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input01.txt","Output":"=== CONT  TestPrescan/input01.txt\n"}
+{"Time":"2018-12-16T21:03:39.754194-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input02.txt"}
+{"Time":"2018-12-16T21:03:39.75421-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input02.txt","Output":"=== CONT  TestPrescan/input02.txt\n"}
+{"Time":"2018-12-16T21:03:39.754678-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input04.txt"}
+{"Time":"2018-12-16T21:03:39.754692-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input04.txt","Output":"=== CONT  TestPrescan/input04.txt\n"}
+{"Time":"2018-12-16T21:03:39.755253-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input03.txt"}
+{"Time":"2018-12-16T21:03:39.755267-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input03.txt","Output":"=== CONT  TestPrescan/input03.txt\n"}
+{"Time":"2018-12-16T21:03:39.755871-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_1"}
+{"Time":"2018-12-16T21:03:39.755886-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_1","Output":"=== CONT  TestNewEvent/event_1\n"}
+{"Time":"2018-12-16T21:03:39.756199-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan","Output":"--- FAIL: TestPrescan (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.756213-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input01.txt","Output":"    --- PASS: TestPrescan/input01.txt (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.756221-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input01.txt","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.756231-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input02.txt","Output":"    --- PASS: TestPrescan/input02.txt (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.756238-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input02.txt","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.756244-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input04.txt","Output":"    --- PASS: TestPrescan/input04.txt (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.756251-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input04.txt","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.756257-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input03.txt","Output":"    --- PASS: TestPrescan/input03.txt (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.756372-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan/input03.txt","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.756383-05:00","Action":"fail","Package":"github.com/mfridman/tparse/parse","Test":"TestPrescan","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.756389-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_9"}
+{"Time":"2018-12-16T21:03:39.756409-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_9","Output":"=== CONT  TestNewEvent/event_9\n"}
+{"Time":"2018-12-16T21:03:39.756674-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_7"}
+{"Time":"2018-12-16T21:03:39.756685-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_7","Output":"=== CONT  TestNewEvent/event_7\n"}
+{"Time":"2018-12-16T21:03:39.757067-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_8"}
+{"Time":"2018-12-16T21:03:39.757079-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_8","Output":"=== CONT  TestNewEvent/event_8\n"}
+{"Time":"2018-12-16T21:03:39.757454-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_6"}
+{"Time":"2018-12-16T21:03:39.757467-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_6","Output":"=== CONT  TestNewEvent/event_6\n"}
+{"Time":"2018-12-16T21:03:39.75765-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_5"}
+{"Time":"2018-12-16T21:03:39.757661-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_5","Output":"=== CONT  TestNewEvent/event_5\n"}
+{"Time":"2018-12-16T21:03:39.757829-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_3"}
+{"Time":"2018-12-16T21:03:39.75784-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_3","Output":"=== CONT  TestNewEvent/event_3\n"}
+{"Time":"2018-12-16T21:03:39.757984-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_4"}
+{"Time":"2018-12-16T21:03:39.757996-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_4","Output":"=== CONT  TestNewEvent/event_4\n"}
+{"Time":"2018-12-16T21:03:39.758175-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_2"}
+{"Time":"2018-12-16T21:03:39.758185-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_2","Output":"=== CONT  TestNewEvent/event_2\n"}
+{"Time":"2018-12-16T21:03:39.75844-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_0"}
+{"Time":"2018-12-16T21:03:39.758456-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_0","Output":"=== CONT  TestNewEvent/event_0\n"}
+{"Time":"2018-12-16T21:03:39.758672-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent","Output":"--- FAIL: TestNewEvent (0.01s)\n"}
+{"Time":"2018-12-16T21:03:39.758694-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_1","Output":"    --- PASS: TestNewEvent/event_1 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.75871-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_1","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.758718-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_9","Output":"    --- PASS: TestNewEvent/event_9 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.758725-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_9","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.758732-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_7","Output":"    --- PASS: TestNewEvent/event_7 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.758739-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_7","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.758745-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_8","Output":"    --- PASS: TestNewEvent/event_8 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.758753-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_8","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.75876-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_6","Output":"    --- PASS: TestNewEvent/event_6 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.758768-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_6","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.758774-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_5","Output":"    --- PASS: TestNewEvent/event_5 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.758787-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_5","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.758794-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_3","Output":"    --- PASS: TestNewEvent/event_3 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.758801-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_3","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.758808-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_4","Output":"    --- PASS: TestNewEvent/event_4 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.758815-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_4","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.758821-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_2","Output":"    --- PASS: TestNewEvent/event_2 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.758828-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_2","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.758834-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_0","Output":"    --- PASS: TestNewEvent/event_0 (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.758844-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent/event_0","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.758849-05:00","Action":"fail","Package":"github.com/mfridman/tparse/parse","Test":"TestNewEvent","Elapsed":0.01}
+{"Time":"2018-12-16T21:03:39.758856-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input02.json"}
+{"Time":"2018-12-16T21:03:39.758861-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input02.json","Output":"=== CONT  TestPanic/input02.json\n"}
+{"Time":"2018-12-16T21:03:39.761879-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input03.json"}
+{"Time":"2018-12-16T21:03:39.761902-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input03.json","Output":"=== CONT  TestPanic/input03.json\n"}
+{"Time":"2018-12-16T21:03:39.765416-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input05.json"}
+{"Time":"2018-12-16T21:03:39.765437-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input05.json","Output":"=== CONT  TestPanic/input05.json\n"}
+{"Time":"2018-12-16T21:03:39.784684-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover/sort"}
+{"Time":"2018-12-16T21:03:39.784714-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover/sort","Output":"=== RUN   TestPackageCover/sort\n"}
+{"Time":"2018-12-16T21:03:39.785195-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover/log"}
+{"Time":"2018-12-16T21:03:39.78521-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover/log","Output":"=== RUN   TestPackageCover/log\n"}
+{"Time":"2018-12-16T21:03:39.785532-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover/bytes"}
+{"Time":"2018-12-16T21:03:39.785543-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover/bytes","Output":"=== RUN   TestPackageCover/bytes\n"}
+{"Time":"2018-12-16T21:03:39.785954-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover","Output":"--- FAIL: TestPackageCover (0.14s)\n"}
+{"Time":"2018-12-16T21:03:39.785983-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover/sort","Output":"    --- PASS: TestPackageCover/sort (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.785993-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover/sort","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.786002-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover/log","Output":"    --- PASS: TestPackageCover/log (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.78601-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover/log","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.786016-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover/bytes","Output":"    --- PASS: TestPackageCover/bytes (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.786032-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover/bytes","Output":"    testing.go:771: race detected during execution of test\n"}
+{"Time":"2018-12-16T21:03:39.786133-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover/bytes","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.786165-05:00","Action":"fail","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCover","Elapsed":0.14}
+{"Time":"2018-12-16T21:03:39.786178-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input04.json"}
+{"Time":"2018-12-16T21:03:39.786253-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input04.json","Output":"=== CONT  TestPanic/input04.json\n"}
+{"Time":"2018-12-16T21:03:39.792339-05:00","Action":"cont","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input01.json"}
+{"Time":"2018-12-16T21:03:39.79236-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input01.json","Output":"=== CONT  TestPanic/input01.json\n"}
+{"Time":"2018-12-16T21:03:39.840423-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic","Output":"--- PASS: TestPanic (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.840452-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input02.json","Output":"    --- PASS: TestPanic/input02.json (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.84046-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input02.json","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.840468-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input03.json","Output":"    --- PASS: TestPanic/input03.json (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.840475-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input03.json","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.840494-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input04.json","Output":"    --- PASS: TestPanic/input04.json (0.01s)\n"}
+{"Time":"2018-12-16T21:03:39.840501-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input04.json","Elapsed":0.01}
+{"Time":"2018-12-16T21:03:39.840507-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input05.json","Output":"    --- PASS: TestPanic/input05.json (0.04s)\n"}
+{"Time":"2018-12-16T21:03:39.840513-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input05.json","Elapsed":0.04}
+{"Time":"2018-12-16T21:03:39.840519-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input01.json","Output":"    --- PASS: TestPanic/input01.json (0.05s)\n"}
+{"Time":"2018-12-16T21:03:39.871682-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic/input01.json","Elapsed":0.05}
+{"Time":"2018-12-16T21:03:39.871773-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPanic","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.871798-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/fmt"}
+{"Time":"2018-12-16T21:03:39.871814-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/fmt","Output":"=== RUN   TestPackageCache/fmt\n"}
+{"Time":"2018-12-16T21:03:39.873023-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/mime"}
+{"Time":"2018-12-16T21:03:39.873043-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/mime","Output":"=== RUN   TestPackageCache/mime\n"}
+{"Time":"2018-12-16T21:03:39.873693-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/time"}
+{"Time":"2018-12-16T21:03:39.873707-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/time","Output":"=== RUN   TestPackageCache/time\n"}
+{"Time":"2018-12-16T21:03:39.87399-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/strings"}
+{"Time":"2018-12-16T21:03:39.874002-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/strings","Output":"=== RUN   TestPackageCache/strings\n"}
+{"Time":"2018-12-16T21:03:39.874273-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache","Output":"--- FAIL: TestPackageCache (0.22s)\n"}
+{"Time":"2018-12-16T21:03:39.874305-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/fmt","Output":"    --- PASS: TestPackageCache/fmt (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.874315-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/fmt","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.874323-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/mime","Output":"    --- PASS: TestPackageCache/mime (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.874331-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/mime","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.874337-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/time","Output":"    --- PASS: TestPackageCache/time (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.874344-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/time","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.87435-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/strings","Output":"    --- PASS: TestPackageCache/strings (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.874357-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/strings","Output":"    testing.go:771: race detected during execution of test\n"}
+{"Time":"2018-12-16T21:03:39.98908-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache/strings","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.989105-05:00","Action":"fail","Package":"github.com/mfridman/tparse/parse","Test":"TestPackageCache","Elapsed":0.22}
+{"Time":"2018-12-16T21:03:39.989113-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/fmt_test"}
+{"Time":"2018-12-16T21:03:39.98912-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/fmt_test","Output":"=== RUN   TestMetrics/fmt_test\n"}
+{"Time":"2018-12-16T21:03:39.990354-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/strings_test"}
+{"Time":"2018-12-16T21:03:39.990372-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/strings_test","Output":"=== RUN   TestMetrics/strings_test\n"}
+{"Time":"2018-12-16T21:03:39.991962-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/bytes_test"}
+{"Time":"2018-12-16T21:03:39.991976-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/bytes_test","Output":"=== RUN   TestMetrics/bytes_test\n"}
+{"Time":"2018-12-16T21:03:39.993049-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/bufio_test"}
+{"Time":"2018-12-16T21:03:39.993064-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/bufio_test","Output":"=== RUN   TestMetrics/bufio_test\n"}
+{"Time":"2018-12-16T21:03:39.993788-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/crypto_test"}
+{"Time":"2018-12-16T21:03:39.993801-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/crypto_test","Output":"=== RUN   TestMetrics/crypto_test\n"}
+{"Time":"2018-12-16T21:03:39.994222-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/log_test"}
+{"Time":"2018-12-16T21:03:39.994236-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/log_test","Output":"=== RUN   TestMetrics/log_test\n"}
+{"Time":"2018-12-16T21:03:39.99473-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/mime_test"}
+{"Time":"2018-12-16T21:03:39.994744-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/mime_test","Output":"=== RUN   TestMetrics/mime_test\n"}
+{"Time":"2018-12-16T21:03:39.995182-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/sort_test"}
+{"Time":"2018-12-16T21:03:39.995195-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/sort_test","Output":"=== RUN   TestMetrics/sort_test\n"}
+{"Time":"2018-12-16T21:03:39.995678-05:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/time_test"}
+{"Time":"2018-12-16T21:03:39.99569-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/time_test","Output":"=== RUN   TestMetrics/time_test\n"}
+{"Time":"2018-12-16T21:03:39.996746-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics","Output":"--- PASS: TestMetrics (0.33s)\n"}
+{"Time":"2018-12-16T21:03:39.99676-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/fmt_test","Output":"    --- PASS: TestMetrics/fmt_test (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.996768-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/fmt_test","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.996776-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/strings_test","Output":"    --- PASS: TestMetrics/strings_test (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.996783-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/strings_test","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.99679-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/bytes_test","Output":"    --- PASS: TestMetrics/bytes_test (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.996797-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/bytes_test","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.996804-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/bufio_test","Output":"    --- PASS: TestMetrics/bufio_test (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.99681-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/bufio_test","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.996827-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/crypto_test","Output":"    --- PASS: TestMetrics/crypto_test (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.996835-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/crypto_test","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.996841-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/log_test","Output":"    --- PASS: TestMetrics/log_test (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.996848-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/log_test","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.996855-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/mime_test","Output":"    --- PASS: TestMetrics/mime_test (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.996861-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/mime_test","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.996867-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/sort_test","Output":"    --- PASS: TestMetrics/sort_test (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.996873-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/sort_test","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.99688-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/time_test","Output":"    --- PASS: TestMetrics/time_test (0.00s)\n"}
+{"Time":"2018-12-16T21:03:39.997152-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics/time_test","Elapsed":0}
+{"Time":"2018-12-16T21:03:39.997163-05:00","Action":"pass","Package":"github.com/mfridman/tparse/parse","Test":"TestMetrics","Elapsed":0.33}
+{"Time":"2018-12-16T21:03:39.997179-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Output":"FAIL\n"}
+{"Time":"2018-12-16T21:03:39.997325-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Output":"coverage: 93.6% of statements\n"}
+{"Time":"2018-12-16T21:03:40.001967-05:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Output":"FAIL\tgithub.com/mfridman/tparse/parse\t0.391s\n"}
+{"Time":"2018-12-16T21:03:40.00199-05:00","Action":"fail","Package":"github.com/mfridman/tparse/parse","Elapsed":0.391}

--- a/parse/testdata/race/output01.golden
+++ b/parse/testdata/race/output01.golden
@@ -1,0 +1,35 @@
+==================
+WARNING: DATA RACE
+Write at 0x00c0000be010 by goroutine 9:
+  command-line-arguments.TestRace1.func1()
+      /Users/michael.fridman/go/src/debug/tparse-24/some_test.go:8 +0x38
+
+Previous write at 0x00c0000be010 by goroutine 6:
+  command-line-arguments.TestRace1()
+      /Users/michael.fridman/go/src/debug/tparse-24/some_test.go:9 +0x96
+  testing.tRunner()
+      /usr/local/go/src/testing/testing.go:827 +0x162
+
+Goroutine 9 (running) created at:
+  command-line-arguments.TestRace1()
+      /Users/michael.fridman/go/src/debug/tparse-24/some_test.go:8 +0x88
+  testing.tRunner()
+      /usr/local/go/src/testing/testing.go:827 +0x162
+
+Goroutine 6 (running) created at:
+  testing.(*T).Run()
+      /usr/local/go/src/testing/testing.go:878 +0x650
+  testing.runTests.func1()
+      /usr/local/go/src/testing/testing.go:1119 +0xa8
+  testing.tRunner()
+      /usr/local/go/src/testing/testing.go:827 +0x162
+  testing.runTests()
+      /usr/local/go/src/testing/testing.go:1117 +0x4ee
+  testing.(*M).Run()
+      /usr/local/go/src/testing/testing.go:1034 +0x2ee
+  main.main()
+      _testmain.go:44 +0x221
+==================
+--- FAIL: TestRace1 (0.00s)
+    some_test.go:10: 64
+    testing.go:771: race detected during execution of test

--- a/parse/testdata/race/output02.golden
+++ b/parse/testdata/race/output02.golden
@@ -1,0 +1,101 @@
+==================
+WARNING: DATA RACE
+Write at 0x00c0000d8938 by goroutine 65:
+  github.com/mfridman/tparse/parse.TestRace2.func1()
+      /Users/michael.fridman/go/src/github.com/mfridman/tparse/parse/some_test.go:17 +0x38
+
+Previous write at 0x00c0000d8938 by goroutine 26:
+  github.com/mfridman/tparse/parse.TestRace2()
+      /Users/michael.fridman/go/src/github.com/mfridman/tparse/parse/some_test.go:18 +0x96
+  testing.tRunner()
+      /usr/local/go/src/testing/testing.go:827 +0x162
+
+Goroutine 65 (running) created at:
+  github.com/mfridman/tparse/parse.TestRace2()
+      /Users/michael.fridman/go/src/github.com/mfridman/tparse/parse/some_test.go:17 +0x88
+  testing.tRunner()
+      /usr/local/go/src/testing/testing.go:827 +0x162
+
+Goroutine 26 (running) created at:
+  testing.(*T).Run()
+      /usr/local/go/src/testing/testing.go:878 +0x650
+  testing.runTests.func1()
+      /usr/local/go/src/testing/testing.go:1119 +0xa8
+  testing.tRunner()
+      /usr/local/go/src/testing/testing.go:827 +0x162
+  testing.runTests()
+      /usr/local/go/src/testing/testing.go:1117 +0x4ee
+  testing.(*M).Run()
+      /usr/local/go/src/testing/testing.go:1034 +0x2ee
+  main.main()
+      _testmain.go:136 +0x332
+==================
+==================
+WARNING: DATA RACE
+Write at 0x00c000014508 by goroutine 63:
+  github.com/mfridman/tparse/parse.TestRace1.func1()
+      /Users/michael.fridman/go/src/github.com/mfridman/tparse/parse/some_test.go:10 +0x38
+
+Previous write at 0x00c000014508 by goroutine 25:
+  github.com/mfridman/tparse/parse.TestRace1()
+      /Users/michael.fridman/go/src/github.com/mfridman/tparse/parse/some_test.go:11 +0x96
+  testing.tRunner()
+      /usr/local/go/src/testing/testing.go:827 +0x162
+
+Goroutine 63 (running) created at:
+  github.com/mfridman/tparse/parse.TestRace1()
+      /Users/michael.fridman/go/src/github.com/mfridman/tparse/parse/some_test.go:10 +0x88
+  testing.tRunner()
+      /usr/local/go/src/testing/testing.go:827 +0x162
+
+Goroutine 25 (running) created at:
+  testing.(*T).Run()
+      /usr/local/go/src/testing/testing.go:878 +0x650
+  testing.runTests.func1()
+      /usr/local/go/src/testing/testing.go:1119 +0xa8
+  testing.tRunner()
+      /usr/local/go/src/testing/testing.go:827 +0x162
+  testing.runTests()
+      /usr/local/go/src/testing/testing.go:1117 +0x4ee
+  testing.(*M).Run()
+      /usr/local/go/src/testing/testing.go:1034 +0x2ee
+  main.main()
+      _testmain.go:136 +0x332
+==================
+--- FAIL: TestSingleFailStack (0.01s)
+    --- FAIL: TestSingleFailStack/input01 (0.00s)
+        stack_test.go:63: 
+            got plain:
+            --- FAIL: TestStatus (0.00s)
+                status_test.go:91: got no failed tests, want one or more tests to be marked as "fail"
+            
+            got quoted:
+            "--- FAIL: TestStatus (0.00s)\n    status_test.go:91: got no failed tests, want one or more tests to be marked as \"fail\"\n"
+        stack_test.go:64: 
+            want plain:
+            --- FAIL: TestStatus (0.00s)
+                status_test.go:91: got no failed tests, want one or more tests to be marked as "fail"
+            
+            want quoted:
+            "--- FAIL: TestStatus (0.00s)\n    status_test.go:91: got no failed tests, want one or more tests to be marked as \"fail\"\n"
+        testing.go:771: race detected during execution of test
+    testing.go:771: race detected during execution of test
+--- FAIL: TestElapsed (0.01s)
+    metrics_test.go:155: expected test names:
+    metrics_test.go:157: TestCompareStrings
+    metrics_test.go:157: TestCaseConsistency
+    testing.go:771: race detected during execution of test
+        big_test.go:60: input01.json 1
+        big_test.go:60: input02.json 7
+        big_test.go:60: input03.json 1
+        big_test.go:60: input04.json 1
+        big_test.go:60: input05.json 1
+        big_test.go:60: input06.json 1
+        big_test.go:60: input07.json 1
+        big_test.go:60: input08.json 1
+--- FAIL: TestPrescan (0.00s)
+--- FAIL: TestNewEvent (0.01s)
+--- FAIL: TestPackageCover (0.14s)
+    testing.go:771: race detected during execution of test
+--- FAIL: TestPackageCache (0.22s)
+    testing.go:771: race detected during execution of test

--- a/parse/testdata/replay/input02.json
+++ b/parse/testdata/replay/input02.json
@@ -1,0 +1,89 @@
+{"Time":"2018-12-16T20:40:10.995055-05:00","Action":"output","Package":"github.com/mfridman/rover","Output":"?   \tgithub.com/mfridman/rover\t[no test files]\n"}
+{"Time":"2018-12-16T20:40:10.995321-05:00","Action":"skip","Package":"github.com/mfridman/rover","Elapsed":0}
+{"Time":"2018-12-16T20:40:10.995346-05:00","Action":"output","Package":"github.com/mfridman/rover/cmd/assets","Output":"?   \tgithub.com/mfridman/rover/cmd/assets\t[no test files]\n"}
+{"Time":"2018-12-16T20:40:10.995468-05:00","Action":"skip","Package":"github.com/mfridman/rover/cmd/assets","Elapsed":0}
+{"Time":"2018-12-16T20:40:11.051713-05:00","Action":"output","Package":"github.com/mfridman/rover/cmd/roverd","Output":"?   \tgithub.com/mfridman/rover/cmd/roverd\t[no test files]\n"}
+{"Time":"2018-12-16T20:40:11.051783-05:00","Action":"skip","Package":"github.com/mfridman/rover/cmd/roverd","Elapsed":0}
+{"Time":"2018-12-16T20:40:11.060625-05:00","Action":"run","Package":"github.com/mfridman/rover/pkg/paging/stringpager","Test":"TestStringPager"}
+{"Time":"2018-12-16T20:40:11.060774-05:00","Action":"output","Package":"github.com/mfridman/rover/pkg/paging/stringpager","Test":"TestStringPager","Output":"=== RUN   TestStringPager\n"}
+{"Time":"2018-12-16T20:40:11.060818-05:00","Action":"run","Package":"github.com/mfridman/rover/pkg/paging/stringpager","Test":"TestStringPager/PageableWithLimit"}
+{"Time":"2018-12-16T20:40:11.060873-05:00","Action":"output","Package":"github.com/mfridman/rover/pkg/paging/stringpager","Test":"TestStringPager/PageableWithLimit","Output":"=== RUN   TestStringPager/PageableWithLimit\n"}
+{"Time":"2018-12-16T20:40:11.06093-05:00","Action":"run","Package":"github.com/mfridman/rover/pkg/paging/stringpager","Test":"TestStringPager/NonPageable"}
+{"Time":"2018-12-16T20:40:11.060946-05:00","Action":"output","Package":"github.com/mfridman/rover/pkg/paging/stringpager","Test":"TestStringPager/NonPageable","Output":"=== RUN   TestStringPager/NonPageable\n"}
+{"Time":"2018-12-16T20:40:11.061077-05:00","Action":"output","Package":"github.com/mfridman/rover/pkg/paging/stringpager","Test":"TestStringPager","Output":"--- PASS: TestStringPager (0.00s)\n"}
+{"Time":"2018-12-16T20:40:11.06115-05:00","Action":"output","Package":"github.com/mfridman/rover/pkg/paging/stringpager","Test":"TestStringPager/PageableWithLimit","Output":"    --- PASS: TestStringPager/PageableWithLimit (0.00s)\n"}
+{"Time":"2018-12-16T20:40:11.061193-05:00","Action":"pass","Package":"github.com/mfridman/rover/pkg/paging/stringpager","Test":"TestStringPager/PageableWithLimit","Elapsed":0}
+{"Time":"2018-12-16T20:40:11.061204-05:00","Action":"output","Package":"github.com/mfridman/rover/pkg/paging/stringpager","Test":"TestStringPager/NonPageable","Output":"    --- PASS: TestStringPager/NonPageable (0.00s)\n"}
+{"Time":"2018-12-16T20:40:11.06121-05:00","Action":"pass","Package":"github.com/mfridman/rover/pkg/paging/stringpager","Test":"TestStringPager/NonPageable","Elapsed":0}
+{"Time":"2018-12-16T20:40:11.061216-05:00","Action":"pass","Package":"github.com/mfridman/rover/pkg/paging/stringpager","Test":"TestStringPager","Elapsed":0}
+{"Time":"2018-12-16T20:40:11.061222-05:00","Action":"output","Package":"github.com/mfridman/rover/pkg/paging/stringpager","Output":"PASS\n"}
+{"Time":"2018-12-16T20:40:11.061235-05:00","Action":"output","Package":"github.com/mfridman/rover/pkg/paging/stringpager","Output":"coverage: 100.0% of statements\n"}
+{"Time":"2018-12-16T20:40:11.063706-05:00","Action":"output","Package":"github.com/mfridman/rover/pkg/paging/stringpager","Output":"ok  \tgithub.com/mfridman/rover/pkg/paging/stringpager\t0.033s\tcoverage: 100.0% of statements\n"}
+{"Time":"2018-12-16T20:40:11.063734-05:00","Action":"pass","Package":"github.com/mfridman/rover/pkg/paging/stringpager","Elapsed":0.033}
+{"Time":"2018-12-16T20:40:11.392671-05:00","Action":"output","Package":"github.com/mfridman/rover/pkg/web","Output":"?   \tgithub.com/mfridman/rover/pkg/web\t[no test files]\n"}
+{"Time":"2018-12-16T20:40:11.39271-05:00","Action":"skip","Package":"github.com/mfridman/rover/pkg/web","Elapsed":0}
+{"Time":"2018-12-16T20:40:11.392737-05:00","Action":"output","Package":"github.com/mfridman/rover/rpc/mailer","Output":"?   \tgithub.com/mfridman/rover/rpc/mailer\t[no test files]\n"}
+{"Time":"2018-12-16T20:40:11.392745-05:00","Action":"skip","Package":"github.com/mfridman/rover/rpc/mailer","Elapsed":0}
+{"Time":"2018-12-16T20:40:11.392763-05:00","Action":"output","Package":"github.com/mfridman/rover/smtp","Output":"?   \tgithub.com/mfridman/rover/smtp\t[no test files]\n"}
+{"Time":"2018-12-16T20:40:11.392771-05:00","Action":"skip","Package":"github.com/mfridman/rover/smtp","Elapsed":0}
+{"Time":"2018-12-16T20:40:11.392787-05:00","Action":"output","Package":"github.com/mfridman/rover/smtp/smtpserver","Output":"?   \tgithub.com/mfridman/rover/smtp/smtpserver\t[no test files]\n"}
+{"Time":"2018-12-16T20:40:11.392799-05:00","Action":"skip","Package":"github.com/mfridman/rover/smtp/smtpserver","Elapsed":0}
+{"Time":"2018-12-16T20:40:11.392849-05:00","Action":"output","Package":"github.com/mfridman/rover/storage","Output":"?   \tgithub.com/mfridman/rover/storage\t[no test files]\n"}
+{"Time":"2018-12-16T20:40:11.392859-05:00","Action":"skip","Package":"github.com/mfridman/rover/storage","Elapsed":0}
+{"Time":"2018-12-16T20:40:11.392882-05:00","Action":"output","Package":"github.com/mfridman/rover/storage/badger","Output":"?   \tgithub.com/mfridman/rover/storage/badger\t[no test files]\n"}
+{"Time":"2018-12-16T20:40:11.39289-05:00","Action":"skip","Package":"github.com/mfridman/rover/storage/badger","Elapsed":0}
+{"Time":"2018-12-16T20:40:12.044953-05:00","Action":"run","Package":"github.com/mfridman/rover/tests/helper","Test":"TestNameFormat"}
+{"Time":"2018-12-16T20:40:12.045003-05:00","Action":"output","Package":"github.com/mfridman/rover/tests/helper","Test":"TestNameFormat","Output":"=== RUN   TestNameFormat\n"}
+{"Time":"2018-12-16T20:40:12.045042-05:00","Action":"output","Package":"github.com/mfridman/rover/tests/helper","Test":"TestNameFormat","Output":"--- PASS: TestNameFormat (0.00s)\n"}
+{"Time":"2018-12-16T20:40:12.045075-05:00","Action":"pass","Package":"github.com/mfridman/rover/tests/helper","Test":"TestNameFormat","Elapsed":0}
+{"Time":"2018-12-16T20:40:12.045093-05:00","Action":"output","Package":"github.com/mfridman/rover/tests/helper","Output":"PASS\n"}
+{"Time":"2018-12-16T20:40:12.045101-05:00","Action":"output","Package":"github.com/mfridman/rover/tests/helper","Output":"coverage: 0.0% of statements\n"}
+{"Time":"2018-12-16T20:40:12.045966-05:00","Action":"output","Package":"github.com/mfridman/rover/tests/helper","Output":"ok  \tgithub.com/mfridman/rover/tests/helper\t0.030s\tcoverage: 0.0% of statements\n"}
+{"Time":"2018-12-16T20:40:12.045999-05:00","Action":"pass","Package":"github.com/mfridman/rover/tests/helper","Elapsed":0.03}
+{"Time":"2018-12-16T20:40:12.236286-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Output":"2018/12/16 20:40:12 Replaying from value pointer: {Fid:0 Len:0 Offset:0}\n"}
+{"Time":"2018-12-16T20:40:12.236372-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Output":"2018/12/16 20:40:12 Iterating file id: 0\n"}
+{"Time":"2018-12-16T20:40:12.236401-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Output":"2018/12/16 20:40:12 Iteration took: 80.538µs\n"}
+{"Time":"2018-12-16T20:40:12.238659-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Output":"2018/12/16 20:40:12 Replaying from value pointer: {Fid:0 Len:0 Offset:0}\n"}
+{"Time":"2018-12-16T20:40:12.238682-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Output":"2018/12/16 20:40:12 Iterating file id: 0\n"}
+{"Time":"2018-12-16T20:40:12.238693-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Output":"2018/12/16 20:40:12 Iteration took: 43.759µs\n"}
+{"Time":"2018-12-16T20:40:12.238882-05:00","Action":"run","Package":"github.com/mfridman/rover/tests","Test":"TestAddEmail"}
+{"Time":"2018-12-16T20:40:12.238893-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestAddEmail","Output":"=== RUN   TestAddEmail\n"}
+{"Time":"2018-12-16T20:40:12.238957-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestAddEmail","Output":"=== PAUSE TestAddEmail\n"}
+{"Time":"2018-12-16T20:40:12.238979-05:00","Action":"pause","Package":"github.com/mfridman/rover/tests","Test":"TestAddEmail"}
+{"Time":"2018-12-16T20:40:12.238995-05:00","Action":"run","Package":"github.com/mfridman/rover/tests","Test":"TestDeleteEmail"}
+{"Time":"2018-12-16T20:40:12.239015-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestDeleteEmail","Output":"=== RUN   TestDeleteEmail\n"}
+{"Time":"2018-12-16T20:40:12.239024-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestDeleteEmail","Output":"=== PAUSE TestDeleteEmail\n"}
+{"Time":"2018-12-16T20:40:12.23903-05:00","Action":"pause","Package":"github.com/mfridman/rover/tests","Test":"TestDeleteEmail"}
+{"Time":"2018-12-16T20:40:12.239043-05:00","Action":"run","Package":"github.com/mfridman/rover/tests","Test":"TestMarkAsRead"}
+{"Time":"2018-12-16T20:40:12.23905-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestMarkAsRead","Output":"=== RUN   TestMarkAsRead\n"}
+{"Time":"2018-12-16T20:40:12.239059-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestMarkAsRead","Output":"=== PAUSE TestMarkAsRead\n"}
+{"Time":"2018-12-16T20:40:12.239065-05:00","Action":"pause","Package":"github.com/mfridman/rover/tests","Test":"TestMarkAsRead"}
+{"Time":"2018-12-16T20:40:12.239076-05:00","Action":"run","Package":"github.com/mfridman/rover/tests","Test":"TestMarkAsUnRead"}
+{"Time":"2018-12-16T20:40:12.239083-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestMarkAsUnRead","Output":"=== RUN   TestMarkAsUnRead\n"}
+{"Time":"2018-12-16T20:40:12.239217-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestMarkAsUnRead","Output":"=== PAUSE TestMarkAsUnRead\n"}
+{"Time":"2018-12-16T20:40:12.239228-05:00","Action":"pause","Package":"github.com/mfridman/rover/tests","Test":"TestMarkAsUnRead"}
+{"Time":"2018-12-16T20:40:12.239237-05:00","Action":"cont","Package":"github.com/mfridman/rover/tests","Test":"TestAddEmail"}
+{"Time":"2018-12-16T20:40:12.239243-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestAddEmail","Output":"=== CONT  TestAddEmail\n"}
+{"Time":"2018-12-16T20:40:12.23926-05:00","Action":"cont","Package":"github.com/mfridman/rover/tests","Test":"TestMarkAsUnRead"}
+{"Time":"2018-12-16T20:40:12.239267-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestMarkAsUnRead","Output":"=== CONT  TestMarkAsUnRead\n"}
+{"Time":"2018-12-16T20:40:12.239274-05:00","Action":"cont","Package":"github.com/mfridman/rover/tests","Test":"TestMarkAsRead"}
+{"Time":"2018-12-16T20:40:12.23928-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestMarkAsRead","Output":"=== CONT  TestMarkAsRead\n"}
+{"Time":"2018-12-16T20:40:12.239287-05:00","Action":"cont","Package":"github.com/mfridman/rover/tests","Test":"TestDeleteEmail"}
+{"Time":"2018-12-16T20:40:12.239293-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestDeleteEmail","Output":"=== CONT  TestDeleteEmail\n"}
+{"Time":"2018-12-16T20:40:12.242303-05:00","Action":"run","Package":"github.com/mfridman/rover/tests","Test":"TestAddEmail/retrieveEmail"}
+{"Time":"2018-12-16T20:40:12.242325-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestAddEmail/retrieveEmail","Output":"=== RUN   TestAddEmail/retrieveEmail\n"}
+{"Time":"2018-12-16T20:40:12.242623-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestAddEmail","Output":"--- PASS: TestAddEmail (0.00s)\n"}
+{"Time":"2018-12-16T20:40:12.242654-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestAddEmail/retrieveEmail","Output":"    --- PASS: TestAddEmail/retrieveEmail (0.00s)\n"}
+{"Time":"2018-12-16T20:40:12.242998-05:00","Action":"pass","Package":"github.com/mfridman/rover/tests","Test":"TestAddEmail/retrieveEmail","Elapsed":0}
+{"Time":"2018-12-16T20:40:12.243014-05:00","Action":"pass","Package":"github.com/mfridman/rover/tests","Test":"TestAddEmail","Elapsed":0}
+{"Time":"2018-12-16T20:40:12.243021-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestDeleteEmail","Output":"--- PASS: TestDeleteEmail (0.00s)\n"}
+{"Time":"2018-12-16T20:40:12.243303-05:00","Action":"pass","Package":"github.com/mfridman/rover/tests","Test":"TestDeleteEmail","Elapsed":0}
+{"Time":"2018-12-16T20:40:12.24332-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestMarkAsRead","Output":"--- PASS: TestMarkAsRead (0.00s)\n"}
+{"Time":"2018-12-16T20:40:12.243971-05:00","Action":"pass","Package":"github.com/mfridman/rover/tests","Test":"TestMarkAsRead","Elapsed":0}
+{"Time":"2018-12-16T20:40:12.243995-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Test":"TestMarkAsUnRead","Output":"--- PASS: TestMarkAsUnRead (0.00s)\n"}
+{"Time":"2018-12-16T20:40:12.244006-05:00","Action":"pass","Package":"github.com/mfridman/rover/tests","Test":"TestMarkAsUnRead","Elapsed":0}
+{"Time":"2018-12-16T20:40:12.244021-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Output":"PASS\n"}
+{"Time":"2018-12-16T20:40:12.24403-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Output":"coverage: 0.0% of statements\n"}
+{"Time":"2018-12-16T20:40:12.244036-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Output":"server closed\n"}
+{"Time":"2018-12-16T20:40:12.246183-05:00","Action":"output","Package":"github.com/mfridman/rover/tests","Output":"ok  \tgithub.com/mfridman/rover/tests\t0.046s\tcoverage: 0.0% of statements\n"}
+{"Time":"2018-12-16T20:40:12.246208-05:00","Action":"pass","Package":"github.com/mfridman/rover/tests","Elapsed":0.046}

--- a/parse/testdata/replay/output02.golden
+++ b/parse/testdata/replay/output02.golden
@@ -1,0 +1,51 @@
+?   	github.com/mfridman/rover	[no test files]
+?   	github.com/mfridman/rover/cmd/assets	[no test files]
+?   	github.com/mfridman/rover/cmd/roverd	[no test files]
+=== RUN   TestStringPager
+=== RUN   TestStringPager/PageableWithLimit
+=== RUN   TestStringPager/NonPageable
+--- PASS: TestStringPager (0.00s)
+    --- PASS: TestStringPager/PageableWithLimit (0.00s)
+    --- PASS: TestStringPager/NonPageable (0.00s)
+PASS
+coverage: 100.0% of statements
+ok  	github.com/mfridman/rover/pkg/paging/stringpager	0.033s	coverage: 100.0% of statements
+?   	github.com/mfridman/rover/pkg/web	[no test files]
+?   	github.com/mfridman/rover/rpc/mailer	[no test files]
+?   	github.com/mfridman/rover/smtp	[no test files]
+?   	github.com/mfridman/rover/smtp/smtpserver	[no test files]
+?   	github.com/mfridman/rover/storage	[no test files]
+?   	github.com/mfridman/rover/storage/badger	[no test files]
+=== RUN   TestNameFormat
+--- PASS: TestNameFormat (0.00s)
+PASS
+coverage: 0.0% of statements
+ok  	github.com/mfridman/rover/tests/helper	0.030s	coverage: 0.0% of statements
+2018/12/16 20:40:12 Replaying from value pointer: {Fid:0 Len:0 Offset:0}
+2018/12/16 20:40:12 Iterating file id: 0
+2018/12/16 20:40:12 Iteration took: 80.538µs
+2018/12/16 20:40:12 Replaying from value pointer: {Fid:0 Len:0 Offset:0}
+2018/12/16 20:40:12 Iterating file id: 0
+2018/12/16 20:40:12 Iteration took: 43.759µs
+=== RUN   TestAddEmail
+=== PAUSE TestAddEmail
+=== RUN   TestDeleteEmail
+=== PAUSE TestDeleteEmail
+=== RUN   TestMarkAsRead
+=== PAUSE TestMarkAsRead
+=== RUN   TestMarkAsUnRead
+=== PAUSE TestMarkAsUnRead
+=== CONT  TestAddEmail
+=== CONT  TestMarkAsUnRead
+=== CONT  TestMarkAsRead
+=== CONT  TestDeleteEmail
+=== RUN   TestAddEmail/retrieveEmail
+--- PASS: TestAddEmail (0.00s)
+    --- PASS: TestAddEmail/retrieveEmail (0.00s)
+--- PASS: TestDeleteEmail (0.00s)
+--- PASS: TestMarkAsRead (0.00s)
+--- PASS: TestMarkAsUnRead (0.00s)
+PASS
+coverage: 0.0% of statements
+server closed
+ok  	github.com/mfridman/rover/tests	0.046s	coverage: 0.0% of statements


### PR DESCRIPTION
The fix is fairly utilitarian. But it should suffice, see #24 and #28 for more info.

Briefly,
- detect a race based on literal string match:`WARNING: DATA RACE`
- return and handle opaque error
- replay output lines starting from the first `==================`, except the following:
  - an update line: `=== RUN`, `=== PAUSE`, `=== CONT`
  - output lines with no test name
  - any lines containing `--- PASS:` 

This should bring us very close to what `go test` (without -v) would have printed otherwise.

### `go test -race` output

```
==================
WARNING: DATA RACE
Write at 0x00c000012070 by goroutine 9:
  command-line-arguments.TestRace1.func1()
      /Users/michael.fridman/go/src/debug/tparse-24/some_test.go:8 +0x38

Previous write at 0x00c000012070 by goroutine 6:
  command-line-arguments.TestRace1()
      /Users/michael.fridman/go/src/debug/tparse-24/some_test.go:9 +0x96
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:827 +0x162

Goroutine 9 (running) created at:
  command-line-arguments.TestRace1()
      /Users/michael.fridman/go/src/debug/tparse-24/some_test.go:8 +0x88
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:827 +0x162

Goroutine 6 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:878 +0x650
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1119 +0xa8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:827 +0x162
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1117 +0x4ee
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1034 +0x2ee
  main.main()
      _testmain.go:44 +0x221
==================
--- FAIL: TestRace1 (0.00s)
    some_test.go:10: 64
    testing.go:771: race detected during execution of test
FAIL
FAIL	command-line-arguments	0.016s
```

### `go test -race -json | tparse` output

```
==================
WARNING: DATA RACE
Write at 0x00c0000a00b0 by goroutine 9:
  command-line-arguments.TestRace1.func1()
      /Users/michael.fridman/go/src/debug/tparse-24/some_test.go:8 +0x38

Previous write at 0x00c0000a00b0 by goroutine 6:
  command-line-arguments.TestRace1()
      /Users/michael.fridman/go/src/debug/tparse-24/some_test.go:9 +0x96
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:827 +0x162

Goroutine 9 (running) created at:
  command-line-arguments.TestRace1()
      /Users/michael.fridman/go/src/debug/tparse-24/some_test.go:8 +0x88
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:827 +0x162

Goroutine 6 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:878 +0x650
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1119 +0xa8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:827 +0x162
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1117 +0x4ee
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1034 +0x2ee
  main.main()
      _testmain.go:44 +0x221
==================
--- FAIL: TestRace1 (0.00s)
    some_test.go:10: 64
    testing.go:771: race detected during execution of test
--- FAIL: TestA (0.00s)
```