### PR TITLE
Don't group slow tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -337,31 +337,32 @@ func (w *consoleWriter) TestsTable(pkgs parse.Packages, options testsTableOption
 	numPkgs := len(sp)
 	numScanned := 0
 
-	for _, pkg := range sp {
-		numScanned++
+	if options.slow != 0 {
+		var skipped []*parse.Test
+		var passed []*parse.Test
+
+		for _, pkg := range sp {
+			numScanned++
+
+			if options.skip {
+				skipped = append(skipped, pkg.TestsByAction(parse.ActionSkip)...)
+			}
+			if options.pass {
+				passed = append(passed, pkg.TestsByAction(parse.ActionPass)...)
+			}
+		}
+
+		// Sort tests within a package by elapsed time in descending order, longest on top.
+		sort.Slice(passed, func(i, j int) bool {
+			return passed[i].Elapsed() > passed[j].Elapsed()
+		})
+		if options.slow > 0 && len(passed) > options.slow {
+			passed = passed[:options.slow]
+		}
 
 		var all []*parse.Test
-		if options.skip {
-			skipped := pkg.TestsByAction(parse.ActionSkip)
-			all = append(all, skipped...)
-		}
-		if options.pass {
-			passed := pkg.TestsByAction(parse.ActionPass)
-
-			// Sort tests within a package by elapsed time in descending order, longest on top.
-			sort.Slice(passed, func(i, j int) bool {
-				return passed[i].Elapsed() > passed[j].Elapsed()
-			})
-
-			all = append(all, passed...)
-		}
-		if len(all) == 0 {
-			continue
-		}
-
-		if options.slow > 0 && len(all) > options.slow {
-			all = all[:options.slow]
-		}
+		all = append(all, skipped...)
+		all = append(all, passed...)
 
 		for _, t := range all {
 			t.SortEvents()
@@ -387,10 +388,58 @@ func (w *consoleWriter) TestsTable(pkgs parse.Packages, options testsTableOption
 				filepath.Base(t.Package),
 			})
 		}
+	} else {
+		for _, pkg := range sp {
+			numScanned++
 
-		// Add empty line between package groups except the last package
-		if numScanned < numPkgs {
-			tbl.Append([]string{"", "", "", ""})
+			var all []*parse.Test
+			if options.skip {
+				skipped := pkg.TestsByAction(parse.ActionSkip)
+				all = append(all, skipped...)
+			}
+			if options.pass {
+				passed := pkg.TestsByAction(parse.ActionPass)
+
+				// Sort tests within a package by elapsed time in descending order, longest on top.
+				sort.Slice(passed, func(i, j int) bool {
+					return passed[i].Elapsed() > passed[j].Elapsed()
+				})
+
+				all = append(all, passed...)
+			}
+			if len(all) == 0 {
+				continue
+			}
+
+			for _, t := range all {
+				t.SortEvents()
+
+				var testName strings.Builder
+				testName.WriteString(t.Name)
+				if options.trim && testName.Len() > 32 && strings.Count(testName.String(), "/") > 0 {
+					testName.Reset()
+					ss := strings.Split(t.Name, "/")
+					testName.WriteString(ss[0] + "\n")
+					for i, s := range ss[1:] {
+						testName.WriteString(" /" + s)
+						if i != len(ss[1:])-1 {
+							testName.WriteString("\n")
+						}
+					}
+				}
+
+				tbl.Append([]string{
+					withColor(t.Status(), w.Color),
+					strconv.FormatFloat(t.Elapsed(), 'f', 2, 64),
+					testName.String(),
+					filepath.Base(t.Package),
+				})
+			}
+
+			// Add empty line between package groups except the last package
+			if numScanned < numPkgs {
+				tbl.Append([]string{"", "", "", ""})
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -334,16 +334,11 @@ func (w *consoleWriter) TestsTable(pkgs parse.Packages, options testsTableOption
 		sp = append(sp, pkg)
 	}
 
-	numPkgs := len(sp)
-	numScanned := 0
-
 	if options.slow != 0 {
 		var skipped []*parse.Test
 		var passed []*parse.Test
 
 		for _, pkg := range sp {
-			numScanned++
-
 			if options.skip {
 				skipped = append(skipped, pkg.TestsByAction(parse.ActionSkip)...)
 			}
@@ -389,9 +384,7 @@ func (w *consoleWriter) TestsTable(pkgs parse.Packages, options testsTableOption
 			})
 		}
 	} else {
-		for _, pkg := range sp {
-			numScanned++
-
+		for i, pkg := range sp {
 			var all []*parse.Test
 			if options.skip {
 				skipped := pkg.TestsByAction(parse.ActionSkip)
@@ -437,7 +430,7 @@ func (w *consoleWriter) TestsTable(pkgs parse.Packages, options testsTableOption
 			}
 
 			// Add empty line between package groups except the last package
-			if numScanned < numPkgs {
+			if i+1 < len(sp) {
 				tbl.Append([]string{"", "", "", ""})
 			}
 		}


### PR DESCRIPTION
This allows `-slow 5` to limit output to only 5 slowest tests, or `-slow -1` to all slowest tests.

Fixes #34 