### PR TITLE
Fixes #43 and #44

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        go: ['1.11','1.12','1.13']
+        go: ['1.13', '1.14', '1.15']
     env:
       VERBOSE: 1
 
@@ -25,7 +25,7 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v1
-        
+
       - name: Build
         run: go build -v .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 10
       matrix:
         go: ['1.13', '1.14', '1.15']
     env:
@@ -19,12 +18,12 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
 
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Build
         run: go build -v .

--- a/parse/stack_test.go
+++ b/parse/stack_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestSingleFailStack(t *testing.T) {
+func TestSingleTestFailStack(t *testing.T) {
 
 	t.Parallel()
 
@@ -21,6 +21,7 @@ func TestSingleFailStack(t *testing.T) {
 		{"input02", filepath.Join(base, "input02.json"), filepath.Join(base, "output02.golden")},
 		{"input03", filepath.Join(base, "input03.json"), filepath.Join(base, "output03.golden")},
 		{"input04", filepath.Join(base, "input04.json"), filepath.Join(base, "output04.golden")},
+		{"input05", filepath.Join(base, "input05.json"), filepath.Join(base, "output05.golden")},
 	}
 
 	for _, test := range tt {

--- a/parse/test.go
+++ b/parse/test.go
@@ -49,32 +49,16 @@ func (t *Test) Status() Action {
 
 // Stack returns debugging information from output events for failed or skipped tests.
 func (t *Test) Stack() string {
-
-	// Sort by time and scan for the first output containing the string
-	// "--- FAIL" or "--- SKIP"; this event marks the beginning for the "stack".
-	// Record it and continue adding all subsequent lines.
 	t.SortEvents()
-
 	var stack strings.Builder
 
-	var scan bool
 	for _, e := range t.Events {
 		// Only output events have useful information. Skip everything else.
 		if e.Action != ActionOutput {
 			continue
 		}
 
-		if scan {
-			stack.WriteString(e.Output)
-			continue
-		}
-
-		for i := range reports {
-			if strings.Contains(e.Output, reports[i]) {
-				scan = true
-				stack.WriteString(e.Output)
-			}
-		}
+		stack.WriteString(e.Output)
 	}
 
 	return stack.String()

--- a/parse/testdata/stack/input05.json
+++ b/parse/testdata/stack/input05.json
@@ -1,0 +1,8 @@
+{"Time":"2020-08-29T12:56:10.668125-04:00","Action":"run","Package":"github.com/mfridman/tparse/parse","Test":"TestIssue_43"}
+{"Time":"2020-08-29T12:56:10.668391-04:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestIssue_43","Output":"=== RUN   TestIssue_43\n"}
+{"Time":"2020-08-29T12:56:10.668421-04:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestIssue_43","Output":"    bug_fix_test.go:16: unexpected end of JSON input\n"}
+{"Time":"2020-08-29T12:56:10.668448-04:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Test":"TestIssue_43","Output":"--- FAIL: TestIssue_43 (0.00s)\n"}
+{"Time":"2020-08-29T12:56:10.668456-04:00","Action":"fail","Package":"github.com/mfridman/tparse/parse","Test":"TestIssue_43","Elapsed":0}
+{"Time":"2020-08-29T12:56:10.668471-04:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Output":"FAIL\n"}
+{"Time":"2020-08-29T12:56:10.668679-04:00","Action":"output","Package":"github.com/mfridman/tparse/parse","Output":"FAIL\tgithub.com/mfridman/tparse/parse\t0.054s\n"}
+{"Time":"2020-08-29T12:56:10.668715-04:00","Action":"fail","Package":"github.com/mfridman/tparse/parse","Elapsed":0.054}

--- a/parse/testdata/stack/output05.golden
+++ b/parse/testdata/stack/output05.golden
@@ -1,0 +1,2 @@
+    bug_fix_test.go:16: unexpected end of JSON input
+--- FAIL: TestIssue_43 (0.00s)


### PR DESCRIPTION
When returning results for a single test, the `*Test.Stack()` method scanned to the first instance of `"--- FAIL"` and recorded output from that point forward.

But, there appears to be cases where that logic is reversed, e.g., 

```
    bug_fix_test.go:16: unexpected end of JSON input
--- FAIL: TestIssue_43 (0.00s)

```

Instead of

```
    --- FAIL: TestCatch/catchAndRetrieve (0.00s)
        catch_test.go:29: got id "ad0892h", want empty id
        catch_test.go:37: email id does not match: got "69c47b65-0ad5-47d5-9346-f4f8bd22c56e", want "oops@example.com"
        catch_test.go:41: failed to mark email as read: failed to mark email id "123" as read: PUT "http://localhost:8026/api/v1/emails/123/read": expecting valid status code, got 500 Internal Server Error

```

(that's not a formatting error `tparse` will respect that raw output from `go test -json` Output field).

So, the fix is to return all output for the given test.

There might be reports of "too noisy" summary, but we'll need real world examples.