### PR TITLE
Bump go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.13', '1.14', '1.15']
+        go: ["1.15", "1.16", "1.17"]
     env:
       VERBOSE: 1
 


### PR DESCRIPTION
Update go version to latest 3 supported: 1.15, 1.16, 1.17