### PR TITLE
Catch build and setup failures; return correct exit code

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -50,11 +50,9 @@ func Run(w io.Writer, option Options) (int, error) {
 		return 1, fmt.Errorf("found no go test packages")
 	}
 	// Useful for tests that don't need additional output.
-	if option.DisableTableOutput {
-		return 0, nil
+	if !option.DisableTableOutput {
+		display(w, summary, option)
 	}
-	display(w, summary, option)
-
 	return summary.ExitCode(), nil
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -24,16 +24,16 @@ type Options struct {
 	Progress bool
 }
 
-func Run(w io.Writer, option Options) error {
+func Run(w io.Writer, option Options) (int, error) {
 	var reader io.ReadCloser
 	var err error
 	if option.FileName != "" {
 		if reader, err = os.Open(option.FileName); err != nil {
-			return err
+			return 1, err
 		}
 	} else {
 		if reader, err = newPipeReader(); err != nil {
-			return errors.New("stdin must be a pipe, or use -file to open go test output file")
+			return 1, errors.New("stdin must be a pipe, or use -file to open go test output file")
 		}
 	}
 	defer reader.Close()
@@ -44,16 +44,18 @@ func Run(w io.Writer, option Options) error {
 		parse.WithWriter(w),
 	)
 	if err != nil {
-		return err
+		return 1, err
 	}
 	if len(summary.Packages) == 0 {
-		return fmt.Errorf("found no go test packages")
+		return 1, fmt.Errorf("found no go test packages")
 	}
 	// Useful for tests that don't need additional output.
 	if option.DisableTableOutput {
-		return nil
+		return 0, nil
 	}
-	return display(w, summary, option)
+	display(w, summary, option)
+
+	return summary.ExitCode(), nil
 }
 
 func newPipeReader() (io.ReadCloser, error) {
@@ -68,7 +70,7 @@ func newPipeReader() (io.ReadCloser, error) {
 	return nil, errors.New("stdin must be a pipe")
 }
 
-func display(w io.Writer, summary *parse.GoTestSummary, option Options) error {
+func display(w io.Writer, summary *parse.GoTestSummary, option Options) {
 	cw := newConsoleWriter(w, option.Format, option.DisableColor)
 	// Sort packages by name ASC.
 	packages := summary.GetSortedPackages()
@@ -79,6 +81,4 @@ func display(w io.Writer, summary *parse.GoTestSummary, option Options) error {
 	// Failures (if any) and summary table are always printed.
 	cw.printFailed(packages)
 	cw.summaryTable(packages, option.ShowNoTests)
-
-	return nil
 }

--- a/internal/app/table_summary.go
+++ b/internal/app/table_summary.go
@@ -59,6 +59,19 @@ func (c *consoleWriter) summaryTable(packages []*parse.Package, showNoTests bool
 			notests = append(notests, row)
 			continue
 		}
+		if pkg.HasFailedBuildOrSetup {
+			row := summaryRow{
+				status:      c.red("FAIL", true),
+				elapsed:     elapsed,
+				packageName: packageName + "\n[" + pkg.Summary.Output + "]",
+				cover:       "--",
+				pass:        "--",
+				fail:        "--",
+				skip:        "--",
+			}
+			passed = append(notests, row)
+			continue
+		}
 		if pkg.NoTests {
 			// This should capture cases where packages truly have no tests, but empty files.
 			if len(pkg.NoTestSlice) == 0 {

--- a/internal/app/table_summary.go
+++ b/internal/app/table_summary.go
@@ -48,7 +48,7 @@ func (c *consoleWriter) summaryTable(packages []*parse.Package, showNoTests bool
 		}
 		if pkg.HasFailedBuildOrSetup {
 			row := summaryRow{
-				status:      c.red(strings.ToUpper(pkg.Summary.Action.String()), true),
+				status:      c.red("FAIL", true),
 				elapsed:     elapsed,
 				packageName: packageName + "\n[" + pkg.Summary.Output + "]",
 				cover:       "--", pass: "--", fail: "--", skip: "--",

--- a/main.go
+++ b/main.go
@@ -114,12 +114,13 @@ func main() {
 		// Do not expose publically.
 		DisableTableOutput: false,
 	}
-	if err := app.Run(os.Stdout, options); err != nil {
+	exitCode, err := app.Run(os.Stdout, options)
+	if err != nil {
 		msg := err.Error()
 		if errors.Is(err, parse.ErrNotParseable) {
 			msg = "no parseable events: Make sure to run go test with -json flag"
 		}
 		fmt.Fprintln(os.Stderr, msg)
-		os.Exit(1)
 	}
+	os.Exit(exitCode)
 }

--- a/parse/event.go
+++ b/parse/event.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	coverRe = regexp.MustCompile(`[0-9]{1,3}\.[0-9]{1}\%`)
+	coverRe              = regexp.MustCompile(`[0-9]{1,3}\.[0-9]{1}\%`)
+	failedBuildOrSetupRe = regexp.MustCompile(`^FAIL(.*)\[(build failed|setup failed)\]`)
 )
 
 // Event represents a single line of json output from go test with the -json flag.

--- a/parse/package.go
+++ b/parse/package.go
@@ -35,6 +35,8 @@ type Package struct {
 	HasDataRace bool
 	// DataRaceTests captures an individual test names as having a data race.
 	DataRaceTests []string
+
+	HasFailedBuildOrSetup bool
 }
 
 // newPackage initializes and returns a Package.

--- a/parse/package.go
+++ b/parse/package.go
@@ -36,6 +36,8 @@ type Package struct {
 	// DataRaceTests captures an individual test names as having a data race.
 	DataRaceTests []string
 
+	// HasFailedBuildOrSetup marks the package as having a failed build or setup.
+	// Example: [build failed] or [setup failed]
 	HasFailedBuildOrSetup bool
 }
 

--- a/parse/process.go
+++ b/parse/process.go
@@ -36,7 +36,8 @@ func Process(r io.Reader, optionsFunc ...OptionsFunc) (*GoTestSummary, error) {
 		e, err := NewEvent(sc.Bytes())
 		if err != nil {
 			// We failed to parse a go test JSON event, but there are special cases for failed
-			// builds, setup, etc. Let's special case these and bubble them up in the summary.
+			// builds, setup, etc. Let's special case these and bubble them up in the summary
+			// if the output belongs to a package.
 			summary.AddRawEvent(sc.Text())
 
 			badLines++

--- a/tests/follow_test.go
+++ b/tests/follow_test.go
@@ -35,7 +35,8 @@ func TestFollow(t *testing.T) {
 				DisableTableOutput: true,
 			}
 			var buf bytes.Buffer
-			if err := app.Run(&buf, options); err != nil && !errors.Is(err, test.err) {
+			_, err := app.Run(&buf, options)
+			if err != nil && !errors.Is(err, test.err) {
 				t.Fatal(err)
 			}
 			goldenFile := filepath.Join(base, test.fileName+".golden")

--- a/tests/follow_test.go
+++ b/tests/follow_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/mfridman/tparse/internal/app"
+	"github.com/mfridman/tparse/internal/check"
 	"github.com/mfridman/tparse/parse"
 )
 
@@ -19,27 +20,29 @@ func TestFollow(t *testing.T) {
 	tt := []struct {
 		fileName string
 		err      error
+		exitCode int
 	}{
-		{"test_01", nil},
-		{"test_02", nil},
-		{"test_03", nil},
-		{"test_04", nil},
-		{"test_05", parse.ErrNotParseable},
+		{"test_01", nil, 0},
+		{"test_02", nil, 0},
+		{"test_03", nil, 0},
+		{"test_04", nil, 0},
+		{"test_05", parse.ErrNotParseable, 1},
 	}
-	for _, test := range tt {
-		t.Run(test.fileName, func(t *testing.T) {
-			intputFile := filepath.Join(base, test.fileName+".json")
+	for _, tc := range tt {
+		t.Run(tc.fileName, func(t *testing.T) {
+			intputFile := filepath.Join(base, tc.fileName+".json")
 			options := app.Options{
 				FileName:           intputFile,
 				FollowOutput:       true,
 				DisableTableOutput: true,
 			}
 			var buf bytes.Buffer
-			_, err := app.Run(&buf, options)
-			if err != nil && !errors.Is(err, test.err) {
+			gotExitCode, err := app.Run(&buf, options)
+			if err != nil && !errors.Is(err, tc.err) {
 				t.Fatal(err)
 			}
-			goldenFile := filepath.Join(base, test.fileName+".golden")
+			check.Number(t, gotExitCode, tc.exitCode)
+			goldenFile := filepath.Join(base, tc.fileName+".golden")
 			want, err := ioutil.ReadFile(goldenFile)
 			if err != nil {
 				t.Fatal(err)

--- a/tests/follow_test.go
+++ b/tests/follow_test.go
@@ -22,11 +22,14 @@ func TestFollow(t *testing.T) {
 		err      error
 		exitCode int
 	}{
-		{"test_01", nil, 0},
+		// race detected
+		{"test_01", nil, 1},
 		{"test_02", nil, 0},
 		{"test_03", nil, 0},
 		{"test_04", nil, 0},
 		{"test_05", parse.ErrNotParseable, 1},
+		// build failure in one package
+		{"test_06", nil, 2},
 	}
 	for _, tc := range tt {
 		t.Run(tc.fileName, func(t *testing.T) {

--- a/tests/testdata/follow/test_06.golden
+++ b/tests/testdata/follow/test_06.golden
@@ -1,0 +1,7 @@
+# github.com/marco-m/tparse-bugs [github.com/marco-m/tparse-bugs.test]
+./a_test.go:6:2: undefined: hello
+FAIL	github.com/marco-m/tparse-bugs [build failed]
+=== RUN   TestB
+--- PASS: TestB (0.00s)
+PASS
+ok  	github.com/marco-m/tparse-bugs/b	0.098s

--- a/tests/testdata/follow/test_06.json
+++ b/tests/testdata/follow/test_06.json
@@ -1,0 +1,10 @@
+# github.com/marco-m/tparse-bugs [github.com/marco-m/tparse-bugs.test]
+./a_test.go:6:2: undefined: hello
+FAIL	github.com/marco-m/tparse-bugs [build failed]
+{"Time":"2022-05-25T23:11:20.775252-04:00","Action":"run","Package":"github.com/marco-m/tparse-bugs/b","Test":"TestB"}
+{"Time":"2022-05-25T23:11:20.775449-04:00","Action":"output","Package":"github.com/marco-m/tparse-bugs/b","Test":"TestB","Output":"=== RUN   TestB\n"}
+{"Time":"2022-05-25T23:11:20.775462-04:00","Action":"output","Package":"github.com/marco-m/tparse-bugs/b","Test":"TestB","Output":"--- PASS: TestB (0.00s)\n"}
+{"Time":"2022-05-25T23:11:20.775464-04:00","Action":"pass","Package":"github.com/marco-m/tparse-bugs/b","Test":"TestB","Elapsed":0}
+{"Time":"2022-05-25T23:11:20.775467-04:00","Action":"output","Package":"github.com/marco-m/tparse-bugs/b","Output":"PASS\n"}
+{"Time":"2022-05-25T23:11:20.7755-04:00","Action":"output","Package":"github.com/marco-m/tparse-bugs/b","Output":"ok  \tgithub.com/marco-m/tparse-bugs/b\t0.098s\n"}
+{"Time":"2022-05-25T23:11:20.77551-04:00","Action":"pass","Package":"github.com/marco-m/tparse-bugs/b","Elapsed":0.098}


### PR DESCRIPTION
Fix #54 

```
$ go test -count=1  ./... -json | tparse  ; echo status code: $?
# github.com/marco-m/tparse-bugs [github.com/marco-m/tparse-bugs.test]
./a_test.go:6:2: undefined: hello
┌────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │             PACKAGE              │ COVER │ PASS │ FAIL │ SKIP  │
│─────────┼─────────┼──────────────────────────────────┼───────┼──────┼──────┼───────│
│  FAIL   │ 0.00s   │ github.com/marco-m/tparse-bugs   │ --    │ --   │ --   │ --    │
│         │         │ [build failed]                   │       │      │      │       │
│  PASS   │ 0.06s   │ github.com/marco-m/tparse-bugs/b │ 0.0%  │    1 │    0 │    0  │
└────────────────────────────────────────────────────────────────────────────────────┘
status code: 2
```