### PR TITLE
Add support for sorting table output by cover, elapsed

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -14,6 +14,7 @@ type Options struct {
 	FollowOutput       bool
 	DisableColor       bool
 	Format             OutputFormat
+	Sorter             parse.PackageSorter
 	ShowNoTests        bool
 	FileName           string
 
@@ -71,7 +72,7 @@ func newPipeReader() (io.ReadCloser, error) {
 func display(w io.Writer, summary *parse.GoTestSummary, option Options) {
 	cw := newConsoleWriter(w, option.Format, option.DisableColor)
 	// Sort packages by name ASC.
-	packages := summary.GetSortedPackages()
+	packages := summary.GetSortedPackages(option.Sorter)
 	// Only print the tests table if either pass or skip is true.
 	if option.TestTableOptions.Pass || option.TestTableOptions.Skip {
 		cw.testsTable(packages, option.TestTableOptions)

--- a/internal/app/table_summary.go
+++ b/internal/app/table_summary.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -146,11 +145,6 @@ func (c *consoleWriter) summaryTable(packages []*parse.Package, showNoTests bool
 	if tbl.NumLines() == 0 && len(passed) == 0 && len(notests) == 0 {
 		return
 	}
-	// Sort package tests by name ASC.
-	// TODO(mf): what about sorting by elapsed, probably DESC, to quickly gauge
-	// slow running tests? Too many knobs makes this tool more complicated to use.
-	sortSummaryRows(passed, ASC)
-	sortSummaryRows(notests, ASC)
 
 	for _, p := range passed {
 		tbl.Append(p.toRow())
@@ -196,20 +190,4 @@ func (r summaryRow) toRow() []string {
 		r.fail,
 		r.skip,
 	}
-}
-
-type orderBy int
-
-const (
-	ASC orderBy = iota + 1
-	DESC
-)
-
-func sortSummaryRows(rows []summaryRow, order orderBy) {
-	sort.Slice(rows, func(i, j int) bool {
-		if order == ASC {
-			return rows[i].packageName < rows[j].packageName
-		}
-		return rows[i].packageName > rows[j].packageName
-	})
 }

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ Options:
 	-notests	Display packages containing no test files or empty test files.
 	-smallscreen	Split subtest names vertically to fit on smaller screens.
 	-slow		Number of slowest tests to display. Default is 0, display all.
-	-sort           Sort table output by attribute [name]. Default is name.
+	-sort           Sort table output by attribute [name, elapsed, cover]. Default is name.
 	-nocolor	Disable all colors. (NO_COLOR also supported)
 	-format		The output format for tables [basic, plain, markdown]. Default is basic.
 	-file		Read test output from a file.
@@ -102,8 +102,12 @@ func main() {
 	switch *sortPtr {
 	case "name":
 		sorter = parse.SortByPackageName
+	case "elapsed":
+		sorter = parse.SortByElapsed
+	case "cover":
+		sorter = parse.SortByCoverage
 	default:
-		fmt.Fprintf(os.Stderr, "invalid option:%q. The -sort flag must be one of: name\n", *sortPtr)
+		fmt.Fprintf(os.Stderr, "invalid option:%q. The -sort flag must be one of: name, elapsed or cover\n", *sortPtr)
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ var (
 	fileNamePtr    = flag.String("file", "", "")
 	formatPtr      = flag.String("format", "", "")
 	followPtr      = flag.Bool("follow", false, "")
+	sortPtr        = flag.String("sort", "name", "")
 
 	// TODO(mf): implement this
 	ciPtr = flag.String("ci", "", "")
@@ -50,6 +51,7 @@ Options:
 	-notests	Display packages containing no test files or empty test files.
 	-smallscreen	Split subtest names vertically to fit on smaller screens.
 	-slow		Number of slowest tests to display. Default is 0, display all.
+	-sort           Sort table output by attribute [name]. Default is name.
 	-nocolor	Disable all colors. (NO_COLOR also supported)
 	-format		The output format for tables [basic, plain, markdown]. Default is basic.
 	-file		Read test output from a file.
@@ -96,6 +98,15 @@ func main() {
 		fmt.Fprintf(os.Stderr, "invalid option:%q. The -format flag must be one of: basic, plain or markdown", *formatPtr)
 		return
 	}
+	var sorter parse.PackageSorter
+	switch *sortPtr {
+	case "name":
+		sorter = parse.SortByPackageName
+	default:
+		fmt.Fprintf(os.Stderr, "invalid option:%q. The -sort flag must be one of: name\n", *sortPtr)
+		return
+	}
+
 	if *allPtr {
 		*passPtr = true
 		*skipPtr = true
@@ -116,6 +127,7 @@ func main() {
 			Slow: *slowPtr,
 		},
 		Format:      format,
+		Sorter:      sorter,
 		ShowNoTests: *showNoTestsPtr,
 
 		// Do not expose publically.

--- a/parse/package_slice.go
+++ b/parse/package_slice.go
@@ -1,0 +1,18 @@
+package parse
+
+import (
+	"sort"
+)
+
+type PackageSorter func([]*Package) sort.Interface
+type PackageSlice []*Package
+
+// SortByPackageName sorts packages in ascending alphabetical order.
+func SortByPackageName(packages []*Package) sort.Interface { return PackageSlice(packages) }
+func (packages PackageSlice) Len() int                     { return len(packages) }
+func (packages PackageSlice) Swap(i, j int) {
+	packages[i], packages[j] = packages[j], packages[i]
+}
+func (packages PackageSlice) Less(i, j int) bool {
+	return packages[i].Summary.Package < packages[j].Summary.Package
+}

--- a/parse/package_slice.go
+++ b/parse/package_slice.go
@@ -7,6 +7,9 @@ import (
 type PackageSorter func([]*Package) sort.Interface
 type PackageSlice []*Package
 
+type byCoverage struct{ PackageSlice }
+type byElapsed struct{ PackageSlice }
+
 // SortByPackageName sorts packages in ascending alphabetical order.
 func SortByPackageName(packages []*Package) sort.Interface { return PackageSlice(packages) }
 func (packages PackageSlice) Len() int                     { return len(packages) }
@@ -15,4 +18,16 @@ func (packages PackageSlice) Swap(i, j int) {
 }
 func (packages PackageSlice) Less(i, j int) bool {
 	return packages[i].Summary.Package < packages[j].Summary.Package
+}
+
+// SortByCoverage sorts packages in descending order of code coverage.
+func SortByCoverage(packages []*Package) sort.Interface { return byCoverage{packages} }
+func (packages byCoverage) Less(i, j int) bool {
+	return packages.PackageSlice[i].Coverage > packages.PackageSlice[j].Coverage
+}
+
+// SortByCoverage sorts packages in descending order of elapsed time per package.
+func SortByElapsed(packages []*Package) sort.Interface { return byElapsed{packages} }
+func (packages byElapsed) Less(i, j int) bool {
+	return packages.PackageSlice[i].Summary.Elapsed > packages.PackageSlice[j].Summary.Elapsed
 }

--- a/parse/process.go
+++ b/parse/process.go
@@ -177,14 +177,12 @@ func (s *GoTestSummary) AddEvent(e *Event) {
 	pkg.AddEvent(e)
 }
 
-func (s *GoTestSummary) GetSortedPackages() []*Package {
+func (s *GoTestSummary) GetSortedPackages(sorter PackageSorter) []*Package {
 	packages := make([]*Package, 0, len(s.Packages))
 	for _, pkg := range s.Packages {
 		packages = append(packages, pkg)
 	}
-	sort.Slice(packages, func(i, j int) bool {
-		return packages[i].Summary.Package < packages[j].Summary.Package
-	})
+	sort.Sort(sorter(packages))
 	return packages
 }
 


### PR DESCRIPTION
Add a new `-sort` flag with the options `name` (default), `cover`, `elapsed` so that you can easily see test results ordered by these other attributes:

- Elapsed: Use to identify tests that take longer than others, could be sign of a bug or a poorly written test.
- Cover: Use to identify packages that are less well covered, to encourage extending test coverage in areas that are in the most need.

Tested using variations on the following commands under https://github.com/cilium/cilium/:

```
$ go test ./pkg/ipcache ./pkg/labels ./pkg/types ./pkg/mtu -json -cover . | tparse -sort cover
┌────────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │               PACKAGE                │ COVER │ PASS │ FAIL │ SKIP  │
│─────────┼─────────┼──────────────────────────────────────┼───────┼──────┼──────┼───────│
│  PASS   │  0.00s  │ github.com/cilium/cilium/pkg/mtu     │ 68.4% │  1   │  0   │  0    │
│  PASS   │  0.02s  │ github.com/cilium/cilium/pkg/ipcache │ 61.4% │  4   │  0   │  0    │
│  PASS   │  0.00s  │ github.com/cilium/cilium/pkg/types   │ 46.2% │  1   │  0   │  0    │
│  PASS   │  0.01s  │ github.com/cilium/cilium/pkg/labels  │ 41.7% │  9   │  0   │  0    │
└────────────────────────────────────────────────────────────────────────────────────────┘
```

See individual commits for more details:
- Remove redundant sorting functions
- Abstract package sorting functions
- Add support for sorting by coverage, elapsed
