### PR TITLE
Make summary respect -smallscreen, improve package shortening

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -19,7 +19,8 @@ type Options struct {
 	FileName           string
 
 	// Test table options
-	TestTableOptions TestTableOptions
+	TestTableOptions    TestTableOptions
+	SummaryTableOptions SummaryTableOptions
 
 	// TODO(mf): implement
 	Progress bool
@@ -83,5 +84,5 @@ func display(w io.Writer, summary *parse.GoTestSummary, option Options) {
 	}
 	// Failures (if any) and summary table are always printed.
 	cw.printFailed(packages)
-	cw.summaryTable(packages, option.ShowNoTests)
+	cw.summaryTable(packages, option.ShowNoTests, option.SummaryTableOptions)
 }

--- a/main.go
+++ b/main.go
@@ -130,6 +130,9 @@ func main() {
 			Trim: *smallScreenPtr,
 			Slow: *slowPtr,
 		},
+		SummaryTableOptions: app.SummaryTableOptions{
+			Trim: *smallScreenPtr,
+		},
 		Format:      format,
 		Sorter:      sorter,
 		ShowNoTests: *showNoTestsPtr,


### PR DESCRIPTION
Problems this solves:
1. Summary table is often too wide for CI and `-smallscreen` does nothing
2. Pattern where tests are always put in ./tests of every package they are testing results in package column in test table to be "tests" for all tests.

First problem is solved by removing common prefix from all packages tested and then wrapping the same way tests are on `-smallscreen`

Second one is solved treating trimming and wrapping package name in tests table just like in summary table with `-smallscreen`, just a bit narrower. 

### with `-smallscreen`:

before:
![Selection_082](https://user-images.githubusercontent.com/446070/184012629-7a91f733-3271-4101-82f8-52c0a1a661eb.png)


after:
![Selection_081](https://user-images.githubusercontent.com/446070/184012312-6b4e6b9f-d231-487a-9b55-77b61c884ff9.png)


### without `-smallscreen`:

before:
![Selection_083](https://user-images.githubusercontent.com/446070/184012979-d88b9642-695f-4829-afc1-d23b7eee8ecb.png)

after: 
![Selection_084](https://user-images.githubusercontent.com/446070/184013191-40125bb1-b4d1-4ddb-aca4-8a2610cb425f.png)

