### PR TITLE
Ignore start event added in go1.20

### DIFF
--- a/parse/event.go
+++ b/parse/event.go
@@ -187,6 +187,7 @@ const (
 	ActionFail   Action = "fail"   // test or benchmark failed
 	ActionOutput Action = "output" // test printed output
 	ActionSkip   Action = "skip"   // test was skipped or the package contained no tests
+	ActionStart  Action = "start"  // the start at the beginning of each test program's execution
 )
 
 func (a Action) String() string {

--- a/parse/process.go
+++ b/parse/process.go
@@ -117,6 +117,13 @@ func (s *GoTestSummary) AddEvent(e *Event) {
 	if e.Action == ActionOutput && e.DiscardOutput() {
 		return
 	}
+	// Added in go1.20 to denote the begining of each test program's execution.
+	// ref: https://go.dev/doc/go1.20#tools
+	// TODO(mf): we should record this internally, but to fix malformed output
+	// this ignores this action event for now.
+	if e.Action == ActionStart {
+		return
+	}
 	pkg, ok := s.Packages[e.Package]
 	if !ok {
 		pkg = newPackage()


### PR DESCRIPTION
Fix #88

This is a stop-gap to ignore go1.20 "start" events.

We can likely use this information internally, but this PR aims to be a quick fix to address malformed lines.