### PR TITLE
Display live PASS events for packages that finished testing

### DIFF
--- a/internal/app/table_tests.go
+++ b/internal/app/table_tests.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mfridman/tparse/parse"
@@ -35,6 +36,23 @@ type packageTests struct {
 	skipped      []*parse.Test
 	passedCount  int
 	passed       []*parse.Test
+}
+
+func (c *consoleWriter) styledLastLine(e parse.Event) string {
+	status := c.green(strings.ToUpper(string(e.Action)))
+	pkg := strings.TrimSpace(e.Package)
+	elapsed := time.Duration(e.Elapsed * float64(time.Second))
+
+	if c.format == OutputFormatMarkdown {
+		return fmt.Sprintf("## %s • %s • %s", status, pkg, elapsed)
+	}
+
+	statusStyle := lipgloss.NewStyle().
+		PaddingLeft(3).
+		PaddingRight(2).
+		Render(status)
+
+	return fmt.Sprintf("%s%s in %s", statusStyle, pkg, elapsed)
 }
 
 func (c *consoleWriter) testsTable(packages []*parse.Package, option TestTableOptions) {

--- a/parse/process.go
+++ b/parse/process.go
@@ -62,17 +62,8 @@ func Process(r io.Reader, optionsFunc ...OptionsFunc) (*GoTestSummary, error) {
 		}
 		started = true
 
-		// TODO(mf): when running tparse locally it's very useful to see progress for long
-		// running test suites. Since we have access to the event we can send it on a chan
-		// or just directly update a spinner-like component. This cannot be run with the
-		// follow option. Lastly, need to consider what local vs CI behaviour would be like.
-		// Depending how often the frames update, this could cause a lot of noise, so maybe
-		// we need to expose an interval option, so in CI it would update infrequently.
-
-		// Optionally, as test output is piped to us we write the plain
-		// text Output as if go test was run without the -json flag.
-		if option.follow && option.w != nil {
-			fmt.Fprint(option.w, e.Output)
+		if option.events != nil {
+			option.events <- *e
 		}
 
 		summary.AddEvent(e)

--- a/parse/process_options.go
+++ b/parse/process_options.go
@@ -6,6 +6,7 @@ type options struct {
 	w      io.Writer
 	follow bool
 	debug  bool
+	events chan<- Event
 }
 
 type OptionsFunc func(o *options)
@@ -20,4 +21,8 @@ func WithWriter(w io.Writer) OptionsFunc {
 
 func WithDebug() OptionsFunc {
 	return func(o *options) { o.debug = true }
+}
+
+func WithEvents(c chan<- Event) OptionsFunc {
+	return func(o *options) { o.events = c }
 }


### PR DESCRIPTION
This patch starts a goroutine that takes care of rendering events of particular interest, like test stdio when -follow is specified and PASS lines by default.

This adds a form of interactivity for large/slow test suites, without having to enable -follow, which could be extremely verbose for some code bases.

---

@mfridman I noticed you'd left a TODO in parse/process.go hinting at passing events back to the caller using a channel. I've taken that approach here, adding `displayEvent()` and moving the FollowOutput printer there. My aim is to improve the situation around https://github.com/mfridman/tparse/issues/86 somewhat, as we were seeing Travis timeouts due to lack of output for 10m.

`styledLastLine()` obeys markdown mode, but I'm not sure if that makes sense. Please let me know if this change goes in the right direction and where further improvements could be made.