### PR TITLE
Add partial `-progress` implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,6 @@ coverage:
 
 tidy:
 	GO111MODULE=on go mod tidy && GO111MODULE=on go mod verify
+
+build:
+	go build -o $$GOBIN/tparse main.go

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -22,7 +22,6 @@ type Options struct {
 	TestTableOptions    TestTableOptions
 	SummaryTableOptions SummaryTableOptions
 
-	// TODO(mf): implement
 	Progress bool
 }
 
@@ -35,7 +34,7 @@ func Run(w io.Writer, option Options) (int, error) {
 		}
 	} else {
 		if reader, err = newPipeReader(); err != nil {
-			return 1, errors.New("stdin must be a pipe, or use -file to open go test output file")
+			return 1, errors.New("stdin must be a pipe, or use -file to open a go test output file")
 		}
 	}
 	defer reader.Close()
@@ -44,6 +43,7 @@ func Run(w io.Writer, option Options) (int, error) {
 		reader,
 		parse.WithFollowOutput(option.FollowOutput),
 		parse.WithWriter(w),
+		parse.WithProgress(option.Progress),
 	)
 	if err != nil {
 		return 1, err

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ var (
 	formatPtr      = flag.String("format", "", "")
 	followPtr      = flag.Bool("follow", false, "")
 	sortPtr        = flag.String("sort", "name", "")
+	progressPtr    = flag.Bool("progress", false, "")
 
 	// TODO(mf): implement this
 	ciPtr = flag.String("ci", "", "")
@@ -38,24 +39,25 @@ var (
 )
 
 var usage = `Usage:
-	go test ./... -json | tparse [options...]
-	go test [packages...] -json | tparse [options...]
-	go test [packages...] -json > pkgs.out ; tparse [options...] -file pkgs.out
+    go test ./... -json | tparse [options...]
+    go test [packages...] -json | tparse [options...]
+    go test [packages...] -json > pkgs.out ; tparse [options...] -file pkgs.out
 
 Options:
-	-h		Show help.
-	-v		Show version.
-	-all		Display table event for pass and skip. (Failed items always displayed)
-	-pass		Display table for passed tests.
-	-skip		Display table for skipped tests.
-	-notests	Display packages containing no test files or empty test files.
-	-smallscreen	Split subtest names vertically to fit on smaller screens.
-	-slow		Number of slowest tests to display. Default is 0, display all.
-	-sort           Sort table output by attribute [name, elapsed, cover]. Default is name.
-	-nocolor	Disable all colors. (NO_COLOR also supported)
-	-format		The output format for tables [basic, plain, markdown]. Default is basic.
-	-file		Read test output from a file.
-	-follow		Follow raw output as go test is running.
+    -h             Show help.
+    -v             Show version.
+    -all           Display table event for pass and skip. (Failed items always displayed)
+    -pass          Display table for passed tests.
+    -skip          Display table for skipped tests.
+    -notests       Display packages containing no test files or empty test files.
+    -smallscreen   Split subtest names vertically to fit on smaller screens.
+    -slow          Number of slowest tests to display. Default is 0, display all.
+    -sort          Sort table output by attribute [name, elapsed, cover]. Default is name.
+    -nocolor       Disable all colors. (NO_COLOR also supported)
+    -format        The output format for tables [basic, plain, markdown]. Default is basic.
+    -file          Read test output from a file.
+    -follow        Follow raw output as go test is running.
+    -progress      Print a single summary line for each package. Useful for long running test suites.
 `
 
 var (
@@ -72,6 +74,9 @@ func main() {
 	if *vPtr || *versionPtr {
 		if buildInfo, ok := debug.ReadBuildInfo(); ok && buildInfo != nil && tparseVersion == "" {
 			tparseVersion = buildInfo.Main.Version
+		}
+		if tparseVersion == "" {
+			tparseVersion = "(devel)"
 		}
 		fmt.Fprintf(os.Stdout, "tparse version: %s\n", tparseVersion)
 		return
@@ -136,6 +141,7 @@ func main() {
 		Format:      format,
 		Sorter:      sorter,
 		ShowNoTests: *showNoTestsPtr,
+		Progress:    *progressPtr,
 
 		// Do not expose publically.
 		DisableTableOutput: false,

--- a/parse/process.go
+++ b/parse/process.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -74,6 +75,11 @@ func Process(r io.Reader, optionsFunc ...OptionsFunc) (*GoTestSummary, error) {
 		if option.follow && option.w != nil {
 			fmt.Fprint(option.w, e.Output)
 		}
+		// Progress is a special case of follow, where we only print the
+		// progress of the test suite, but not the output.
+		if option.progress && option.w != nil {
+			printProgress(option.w, e, summary.Packages)
+		}
 
 		summary.AddEvent(e)
 	}
@@ -86,6 +92,46 @@ func Process(r io.Reader, optionsFunc ...OptionsFunc) (*GoTestSummary, error) {
 	}
 
 	return summary, nil
+}
+
+// printProgress prints a single summary line for each PASS or FAIL package.
+// This is useful for long running test suites.
+func printProgress(w io.Writer, e *Event, summary map[string]*Package) {
+	if e.LastLine() {
+		action := e.Action
+		var suffix string
+		if pkg, ok := summary[e.Package]; ok {
+			if pkg.NoTests {
+				suffix = " [no tests to run]"
+				action = ActionSkip
+			}
+			if pkg.NoTestFiles {
+				suffix = " [no test files]"
+				action = ActionSkip
+			}
+		}
+		// Normal go test output will print the package summary line like so:
+		//
+		// FAIL
+		// FAIL    github.com/pressly/goose/v4/internal/sqlparser  0.577s
+		//
+		// PASS
+		// ok      github.com/pressly/goose/v4/internal/sqlparser  0.349s
+		//
+		// ?       github.com/pressly/goose/v4/internal/check      [no test files]
+		//
+		// testing: warning: no tests to run
+		// PASS
+		// ok      github.com/pressly/goose/v4/pkg/source  0.382s [no tests to run]
+		//
+		// We modify this output slightly so it's more consistent and easier to parse.
+		fmt.Fprintf(w, "[%s]\t%10s\t%s%s\n",
+			strings.ToUpper(action.String()),
+			strconv.FormatFloat(e.Elapsed, 'f', 3, 64)+"s",
+			e.Package,
+			suffix,
+		)
+	}
 }
 
 type GoTestSummary struct {

--- a/parse/process.go
+++ b/parse/process.go
@@ -97,41 +97,42 @@ func Process(r io.Reader, optionsFunc ...OptionsFunc) (*GoTestSummary, error) {
 // printProgress prints a single summary line for each PASS or FAIL package.
 // This is useful for long running test suites.
 func printProgress(w io.Writer, e *Event, summary map[string]*Package) {
-	if e.LastLine() {
-		action := e.Action
-		var suffix string
-		if pkg, ok := summary[e.Package]; ok {
-			if pkg.NoTests {
-				suffix = " [no tests to run]"
-				action = ActionSkip
-			}
-			if pkg.NoTestFiles {
-				suffix = " [no test files]"
-				action = ActionSkip
-			}
-		}
-		// Normal go test output will print the package summary line like so:
-		//
-		// FAIL
-		// FAIL    github.com/pressly/goose/v4/internal/sqlparser  0.577s
-		//
-		// PASS
-		// ok      github.com/pressly/goose/v4/internal/sqlparser  0.349s
-		//
-		// ?       github.com/pressly/goose/v4/internal/check      [no test files]
-		//
-		// testing: warning: no tests to run
-		// PASS
-		// ok      github.com/pressly/goose/v4/pkg/source  0.382s [no tests to run]
-		//
-		// We modify this output slightly so it's more consistent and easier to parse.
-		fmt.Fprintf(w, "[%s]\t%10s\t%s%s\n",
-			strings.ToUpper(action.String()),
-			strconv.FormatFloat(e.Elapsed, 'f', 3, 64)+"s",
-			e.Package,
-			suffix,
-		)
+	if !e.LastLine() {
+		return
 	}
+	action := e.Action
+	var suffix string
+	if pkg, ok := summary[e.Package]; ok {
+		if pkg.NoTests {
+			suffix = " [no tests to run]"
+			action = ActionSkip
+		}
+		if pkg.NoTestFiles {
+			suffix = " [no test files]"
+			action = ActionSkip
+		}
+	}
+	// Normal go test output will print the package summary line like so:
+	//
+	// FAIL
+	// FAIL    github.com/pressly/goose/v4/internal/sqlparser  0.577s
+	//
+	// PASS
+	// ok      github.com/pressly/goose/v4/internal/sqlparser  0.349s
+	//
+	// ?       github.com/pressly/goose/v4/internal/check      [no test files]
+	//
+	// testing: warning: no tests to run
+	// PASS
+	// ok      github.com/pressly/goose/v4/pkg/source  0.382s [no tests to run]
+	//
+	// We modify this output slightly so it's more consistent and easier to parse.
+	fmt.Fprintf(w, "[%s]\t%10s\t%s%s\n",
+		strings.ToUpper(action.String()),
+		strconv.FormatFloat(e.Elapsed, 'f', 2, 64)+"s",
+		e.Package,
+		suffix,
+	)
 }
 
 type GoTestSummary struct {

--- a/parse/process_options.go
+++ b/parse/process_options.go
@@ -1,11 +1,14 @@
 package parse
 
-import "io"
+import (
+	"io"
+)
 
 type options struct {
-	w      io.Writer
-	follow bool
-	debug  bool
+	w        io.Writer
+	follow   bool
+	debug    bool
+	progress bool
 }
 
 type OptionsFunc func(o *options)
@@ -20,4 +23,8 @@ func WithWriter(w io.Writer) OptionsFunc {
 
 func WithDebug() OptionsFunc {
 	return func(o *options) { o.debug = true }
+}
+
+func WithProgress(b bool) OptionsFunc {
+	return func(o *options) { o.progress = b }
 }


### PR DESCRIPTION
This PR adds a `-progress` flag, which enables printing Package-level summary output as tests are still running.

For example, the PASS|FAIL|SKIP lines are printed as soon as the package tests are finished. This is useful for long-running test suites with a lot of output where `-progress` is too noisy.

```sh
$ go test ./... -json | tparse -progress
[PASS]      0.200s      github.com/pressly/goose/v4/internal/migrationstats
[FAIL]      0.362s      github.com/pressly/goose/v4/internal/sqlparser
[SKIP]      0.412s      github.com/pressly/goose/v4/pkg/source [no tests to run]
[PASS]     22.866s      github.com/pressly/goose/v4
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃   FAIL  package: github.com/pressly/goose/v4/internal/sqlparser   ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

--- FAIL: TestSemicolons (0.00s)

    parser_test.go:43: incorrect semicolon. got true, want false

┌───────────────────────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │                       PACKAGE                       │ COVER │ PASS │ FAIL │ SKIP  │
│─────────┼─────────┼─────────────────────────────────────────────────────┼───────┼──────┼──────┼───────│
│  PASS   │ 22.87s  │ github.com/pressly/goose/v4                         │  --   │  18  │  0   │  0    │
│  PASS   │  0.20s  │ github.com/pressly/goose/v4/internal/migrationstats │  --   │  10  │  0   │  0    │
│  FAIL   │  0.36s  │ github.com/pressly/goose/v4/internal/sqlparser      │  --   │  11  │  1   │  0    │
└───────────────────────────────────────────────────────────────────────────────────────────────────────┘
```