### PR TITLE
Shorten package name only for -smallscreen

### DIFF
--- a/internal/app/table_tests.go
+++ b/internal/app/table_tests.go
@@ -78,7 +78,7 @@ func (c *consoleWriter) testsTable(packages []*parse.Package, option TestTableOp
 				status = c.red(status)
 			}
 
-			packageName := shortenPackageName(t.Package, packagePrefix, 16, true)
+			packageName := shortenPackageName(t.Package, packagePrefix, 16, option.Trim)
 
 			row := testRow{
 				status:      status,


### PR DESCRIPTION
Fix #91 

The screenshots below **do not** use `-smallscreen`. There might be an opportunity to add a `-trimpath` flag to remove a plain import path component to condense the table. But we'll leave it for now and see if it's an issue.

### Before

<img width="691" alt="CleanShot 2023-05-29 at 08 26 36@2x" src="https://github.com/mfridman/tparse/assets/6278244/cacf3d25-9bf2-41be-9f13-3427a6658db0">

### After

<img width="964" alt="CleanShot 2023-05-29 at 08 27 26@2x" src="https://github.com/mfridman/tparse/assets/6278244/8406e562-d8f1-448e-9250-5fa987cfe106">
