### PR TITLE
chore: bump ci tests go versions

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -10,19 +10,29 @@ import (
 )
 
 type Options struct {
-	DisableTableOutput bool
-	FollowOutput       bool
-	DisableColor       bool
-	Format             OutputFormat
-	Sorter             parse.PackageSorter
-	ShowNoTests        bool
-	FileName           string
+	// DisableColor will disable all colors.
+	DisableColor bool
+	// Format will set the output format for tables.
+	Format OutputFormat
+	// Sorter will set the sort order for the table.
+	Sorter parse.PackageSorter
+	// ShowNoTests will display packages containing no test files or empty test files.
+	ShowNoTests bool
+	// FileName will read test output from a file.
+	FileName string
 
 	// Test table options
 	TestTableOptions    TestTableOptions
 	SummaryTableOptions SummaryTableOptions
 
+	// FollowOutput will follow the raw output as go test is running.
+	FollowOutput bool
+	// Progress will print a single summary line for each package once the package has completed.
+	// Useful for long running test suites. Maybe used with FollowOutput or on its own.
 	Progress bool
+
+	// DisableTableOutput will disable all table output. This is used for testing.
+	DisableTableOutput bool
 }
 
 func Run(w io.Writer, option Options) (int, error) {

--- a/internal/app/table_summary.go
+++ b/internal/app/table_summary.go
@@ -22,7 +22,12 @@ type SummaryTableOptions struct {
 	Trim bool
 }
 
-func (c *consoleWriter) summaryTable(packages []*parse.Package, showNoTests bool, options SummaryTableOptions) {
+func (c *consoleWriter) summaryTable(
+	packages []*parse.Package,
+	showNoTests bool,
+	options SummaryTableOptions,
+	against *parse.GoTestSummary,
+) {
 	var tableString strings.Builder
 	tbl := newTableWriter(&tableString, c.format)
 	tbl.SetColumnAlignment([]int{
@@ -123,6 +128,19 @@ func (c *consoleWriter) summaryTable(packages []*parse.Package, showNoTests bool
 		coverage := "--"
 		if pkg.Cover {
 			coverage = fmt.Sprintf("%.1f%%", pkg.Coverage)
+			if against != nil {
+				// TODO(mf): compute against
+				againstP, ok := against.Packages[pkg.Summary.Package]
+				if ok {
+					var sign string
+					if pkg.Coverage > againstP.Coverage {
+						sign = "+"
+					}
+					coverage = fmt.Sprintf("%s (%s)", coverage, sign+strconv.FormatFloat(pkg.Coverage-againstP.Coverage, 'f', 1, 64)+"%")
+				} else {
+					coverage = fmt.Sprintf("%s (-)", coverage)
+				}
+			}
 			// Showing coverage for a package that failed is a bit odd.
 			//
 			// Only colorize the coverage when everything passed AND the output is not markdown.

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ var (
 	followPtr      = flag.Bool("follow", false, "")
 	sortPtr        = flag.String("sort", "name", "")
 	progressPtr    = flag.Bool("progress", false, "")
+	comparePtr     = flag.String("compare", "", "")
 
 	// TODO(mf): implement this
 	ciPtr = flag.String("ci", "", "")
@@ -59,6 +60,7 @@ Options:
     -file          Read test output from a file.
     -follow        Follow raw output as go test is running.
     -progress      Print a single summary line for each package. Useful for long running test suites.
+    -compare       Compare against a previous test output file. (experimental)
 `
 
 var (
@@ -141,6 +143,7 @@ func main() {
 		Sorter:      sorter,
 		ShowNoTests: *showNoTestsPtr,
 		Progress:    *progressPtr,
+		Compare:     *comparePtr,
 
 		// Do not expose publically.
 		DisableTableOutput: false,

--- a/parse/package_slice.go
+++ b/parse/package_slice.go
@@ -26,7 +26,7 @@ func (packages byCoverage) Less(i, j int) bool {
 	return packages.PackageSlice[i].Coverage > packages.PackageSlice[j].Coverage
 }
 
-// SortByCoverage sorts packages in descending order of elapsed time per package.
+// SortByElapsed sorts packages in descending order of elapsed time per package.
 func SortByElapsed(packages []*Package) sort.Interface { return byElapsed{packages} }
 func (packages byElapsed) Less(i, j int) bool {
 	return packages.PackageSlice[i].Summary.Elapsed > packages.PackageSlice[j].Summary.Elapsed


### PR DESCRIPTION
Remove go1.18 tests and add go1.21 tests.