### PR TITLE
Partial support for `-compare`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.18', '1.19', '1.20']
+        go-version: ['1.19', '1.20', '1.21']
     env:
       VERBOSE: 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Add partial support for `-compare`. A feature that displays the coverage difference against a
+  previous run. See description for more details
+  https://github.com/mfridman/tparse/pull/101#issue-1857786730 and the initial issue https://github.com/mfridman/tparse/issues/92.
+
 ## [v0.13.1] - 2023-08-04
 
 - Fix failing GoReleaser github action (release notes location).

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/mfridman/tparse
 
 require (
 	github.com/charmbracelet/lipgloss v0.7.1
-	github.com/muesli/termenv v0.15.1
+	github.com/muesli/termenv v0.15.2
 	github.com/olekukonko/tablewriter v0.0.5
 )
 

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/charmbracelet/lipgloss v0.7.1/go.mod h1:yG0k3giv8Qj8edTCbbg6AlQ5e8KNW
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
@@ -13,8 +14,9 @@ github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWV
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
-github.com/muesli/termenv v0.15.1 h1:UzuTb/+hhlBugQz28rpzey4ZuKcZ03MeKsoG7IJZIxs=
 github.com/muesli/termenv v0.15.1/go.mod h1:HeAQPTzpfs016yGtA4g00CsdYnVLJvxsS4ANqrZs2sQ=
+github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
+github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -23,5 +25,6 @@ github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -10,19 +10,29 @@ import (
 )
 
 type Options struct {
-	DisableTableOutput bool
-	FollowOutput       bool
-	DisableColor       bool
-	Format             OutputFormat
-	Sorter             parse.PackageSorter
-	ShowNoTests        bool
-	FileName           string
+	// DisableColor will disable all colors.
+	DisableColor bool
+	// Format will set the output format for tables.
+	Format OutputFormat
+	// Sorter will set the sort order for the table.
+	Sorter parse.PackageSorter
+	// ShowNoTests will display packages containing no test files or empty test files.
+	ShowNoTests bool
+	// FileName will read test output from a file.
+	FileName string
 
 	// Test table options
 	TestTableOptions    TestTableOptions
 	SummaryTableOptions SummaryTableOptions
 
+	// FollowOutput will follow the raw output as go test is running.
+	FollowOutput bool
+	// Progress will print a single summary line for each package once the package has completed.
+	// Useful for long running test suites. Maybe used with FollowOutput or on its own.
 	Progress bool
+
+	// DisableTableOutput will disable all table output. This is used for testing.
+	DisableTableOutput bool
 }
 
 func Run(w io.Writer, option Options) (int, error) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -89,10 +89,7 @@ func newPipeReader() (io.ReadCloser, error) {
 }
 
 func display(w io.Writer, summary *parse.GoTestSummary, option Options) {
-	// Best effort to open the comparse file, if it exists.
-	//
-	// TODO(mf): add a warning if the file doesn't exist, but do not fail, and instead print a
-	// warning after the summary table.
+	// Best effort to open the compare against file, if it exists.
 	var warnings []string
 	defer func() {
 		for _, w := range warnings {
@@ -104,12 +101,12 @@ func display(w io.Writer, summary *parse.GoTestSummary, option Options) {
 		// TODO(mf): cleanup, this is messy.
 		f, err := os.Open(option.Compare)
 		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to open compare file: %s", option.Compare))
+			warnings = append(warnings, fmt.Sprintf("failed to open against file: %s", option.Compare))
 		} else {
 			defer f.Close()
 			against, err = parse.Process(f)
 			if err != nil {
-				warnings = append(warnings, fmt.Sprintf("failed to parse compare file: %s", option.Compare))
+				warnings = append(warnings, fmt.Sprintf("failed to parse against file: %s", option.Compare))
 			}
 		}
 	}

--- a/internal/app/table_summary.go
+++ b/internal/app/table_summary.go
@@ -22,7 +22,12 @@ type SummaryTableOptions struct {
 	Trim bool
 }
 
-func (c *consoleWriter) summaryTable(packages []*parse.Package, showNoTests bool, options SummaryTableOptions) {
+func (c *consoleWriter) summaryTable(
+	packages []*parse.Package,
+	showNoTests bool,
+	options SummaryTableOptions,
+	against *parse.GoTestSummary,
+) {
 	var tableString strings.Builder
 	tbl := newTableWriter(&tableString, c.format)
 	tbl.SetColumnAlignment([]int{
@@ -123,6 +128,19 @@ func (c *consoleWriter) summaryTable(packages []*parse.Package, showNoTests bool
 		coverage := "--"
 		if pkg.Cover {
 			coverage = fmt.Sprintf("%.1f%%", pkg.Coverage)
+			if against != nil {
+				// TODO(mf): compute against
+				againstP, ok := against.Packages[pkg.Summary.Package]
+				if ok {
+					var sign string
+					if pkg.Coverage > againstP.Coverage {
+						sign = "+"
+					}
+					coverage = fmt.Sprintf("%s (%s)", coverage, sign+strconv.FormatFloat(pkg.Coverage-againstP.Coverage, 'f', 1, 64)+"%")
+				} else {
+					coverage = fmt.Sprintf("%s (-)", coverage)
+				}
+			}
 			// Showing coverage for a package that failed is a bit odd.
 			//
 			// Only colorize the coverage when everything passed AND the output is not markdown.

--- a/internal/app/table_summary.go
+++ b/internal/app/table_summary.go
@@ -124,12 +124,12 @@ func (c *consoleWriter) summaryTable(
 				continue
 			}
 		}
-
+		// TODO(mf): refactor this
+		// Separate cover colorization from the delta output.
 		coverage := "--"
 		if pkg.Cover {
 			coverage = fmt.Sprintf("%.1f%%", pkg.Coverage)
 			if against != nil {
-				// TODO(mf): compute against
 				againstP, ok := against.Packages[pkg.Summary.Package]
 				if ok {
 					var sign string

--- a/main.go
+++ b/main.go
@@ -63,9 +63,7 @@ Options:
     -compare       Compare against a previous test output file. (experimental)
 `
 
-var (
-	version = "(devel)"
-)
+var version string
 
 func main() {
 	log.SetFlags(0)
@@ -76,7 +74,7 @@ func main() {
 
 	if *vPtr || *versionPtr {
 		buildInfo, ok := debug.ReadBuildInfo()
-		if ok && buildInfo != nil && buildInfo.Main.Version != "" {
+		if ok && buildInfo != nil && buildInfo.Main.Version != "" && version == "" {
 			version = buildInfo.Main.Version
 		}
 		fmt.Fprintf(os.Stdout, "tparse version: %s\n", strings.TrimSpace(version))

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ var (
 	followPtr      = flag.Bool("follow", false, "")
 	sortPtr        = flag.String("sort", "name", "")
 	progressPtr    = flag.Bool("progress", false, "")
+	comparePtr     = flag.String("compare", "", "")
 
 	// TODO(mf): implement this
 	ciPtr = flag.String("ci", "", "")
@@ -59,6 +60,7 @@ Options:
     -file          Read test output from a file.
     -follow        Follow raw output as go test is running.
     -progress      Print a single summary line for each package. Useful for long running test suites.
+    -compare       Compare against a previous test output file. (experimental)
 `
 
 var (
@@ -141,6 +143,7 @@ func main() {
 		Sorter:      sorter,
 		ShowNoTests: *showNoTestsPtr,
 		Progress:    *progressPtr,
+		Compare:     *comparePtr,
 
 		// Do not expose publically.
 		DisableTableOutput: false,

--- a/parse/package_slice.go
+++ b/parse/package_slice.go
@@ -26,7 +26,7 @@ func (packages byCoverage) Less(i, j int) bool {
 	return packages.PackageSlice[i].Coverage > packages.PackageSlice[j].Coverage
 }
 
-// SortByCoverage sorts packages in descending order of elapsed time per package.
+// SortByElapsed sorts packages in descending order of elapsed time per package.
 func SortByElapsed(packages []*Package) sort.Interface { return byElapsed{packages} }
 func (packages byElapsed) Less(i, j int) bool {
 	return packages.PackageSlice[i].Summary.Elapsed > packages.PackageSlice[j].Summary.Elapsed


### PR DESCRIPTION
This PR adds an experimental flag `-compare` to compare the current `go test` run against a previous one.

See #92 for more details, but the brief summary is:

You can run `go test ... -json > output.json`, store the JSON output, and then do another run to compare against the previous one.

A contrived example is to look at Go standard library cover changes between Go versions for select packages, for example:

Go 1.21.0 compared against 1.18.0

```
$ PACKAGES='fmt strings bytes bufio crypto log mime sort time'
$ go1.21 test -count=1 `echo $PACKAGES` -json -cover | tparse -compare go1.18.json

┌───────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │ PACKAGE │     COVER     │ PASS │ FAIL │ SKIP  │
│─────────┼─────────┼─────────┼───────────────┼──────┼──────┼───────│
│  PASS   │  0.62s  │ bufio   │ 93.5% (+0.2%) │  87  │  0   │  0    │
│  PASS   │  2.69s  │ bytes   │ 95.4% (-0.2%) │ 146  │  0   │  0    │
│  PASS   │  0.59s  │ crypto  │  5.9% (0.0%)  │  5   │  0   │  0    │
│  PASS   │  0.39s  │ fmt     │ 95.2% (0.0%)  │  79  │  0   │  1    │
│  PASS   │  0.77s  │ log     │ 67.9% (-0.1%) │  11  │  0   │  0    │
│  PASS   │  0.90s  │ mime    │ 94.0% (+0.2%) │  24  │  0   │  0    │
│  PASS   │  2.96s  │ sort    │ 58.7% (-2.1%) │  76  │  0   │  1    │
│  PASS   │  2.21s  │ strings │ 97.6% (-0.5%) │ 122  │  0   │  0    │
│  PASS   │  8.68s  │ time    │ 92.5% (+0.7%) │ 349  │  0   │  1    │
└───────────────────────────────────────────────────────────────────┘
```

Going to merge this as-is and continue to chip away at refactoring the underlying logic/colorization.