### PR TITLE
Upgrade code to respect new conventions.

### DIFF
--- a/parse/process.go
+++ b/parse/process.go
@@ -43,18 +43,16 @@ func Process(r io.Reader, optionsFunc ...OptionsFunc) (*GoTestSummary, error) {
 
 			badLines++
 			if started || badLines > 50 {
-				switch err.(type) {
-				case *json.SyntaxError:
-					err = fmt.Errorf("line %d json error: %s: %w", badLines, err.Error(), ErrNotParseable)
+				var syntaxError *json.SyntaxError
+				if errors.As(err, &syntaxError) {
+					err = fmt.Errorf("line %d json error: %s: %w", badLines, syntaxError.Error(), ErrNotParseable)
 					if option.debug {
 						// In debug mode we can surface a more verbose error message which
 						// contains the current line number and exact JSON parsing error.
 						fmt.Fprintf(os.Stderr, "debug: %s", err.Error())
 					}
-					return nil, err
-				default:
-					return nil, err
 				}
+				return nil, err
 			}
 			if option.follow && option.w != nil {
 				fmt.Fprintf(option.w, "%s\n", sc.Bytes())

--- a/tests/follow_test.go
+++ b/tests/follow_test.go
@@ -3,7 +3,7 @@ package parsetest
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -46,7 +46,7 @@ func TestFollow(t *testing.T) {
 			}
 			check.Number(t, gotExitCode, tc.exitCode)
 			goldenFile := filepath.Join(base, tc.fileName+".golden")
-			want, err := ioutil.ReadFile(goldenFile)
+			want, err := os.ReadFile(goldenFile)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -56,7 +56,7 @@ func TestFollow(t *testing.T) {
 					"tests/"+goldenFile+".FAIL",
 					"tests/"+intputFile+".FAIL",
 				)
-				if err := ioutil.WriteFile(goldenFile+".FAIL", buf.Bytes(), 0644); err != nil {
+				if err := os.WriteFile(goldenFile+".FAIL", buf.Bytes(), 0644); err != nil {
 					t.Fatal(err)
 				}
 			}


### PR DESCRIPTION
go.mod refers to 1.17, so we can use os.ReadFile and os.WriteFile instead of ioutil.ReadFile and ioutil.WriteFile that are now deprecated.

We should use errors.As since go 1.13 otherwise any wrapped errors won't be caught.
