### PR TITLE
Add test name text wrapping on small screens

### DIFF
--- a/internal/app/table_tests.go
+++ b/internal/app/table_tests.go
@@ -208,7 +208,12 @@ func shortenTestName(s string, trim bool, maxLength int) string {
 		ss := strings.Split(s, "/")
 		testName.WriteString(ss[0] + "\n")
 		for i, s := range ss[1:] {
-			testName.WriteString(" /" + s)
+			testName.WriteString(" /")
+			for len(s) > maxLength {
+				testName.WriteString(s[:maxLength] + "\n  ")
+				s = s[maxLength:]
+			}
+			testName.WriteString(s)
 			if i != len(ss[1:])-1 {
 				testName.WriteString("\n")
 			}

--- a/internal/app/table_tests.go
+++ b/internal/app/table_tests.go
@@ -210,8 +210,8 @@ func shortenTestName(s string, trim bool, maxLength int) string {
 		for i, s := range ss[1:] {
 			testName.WriteString(" /")
 			for len(s) > maxLength {
-				testName.WriteString(s[:maxLength] + "\n  ")
-				s = s[maxLength:]
+				testName.WriteString(s[:maxLength-2] + " …\n  ")
+				s = s[maxLength-2:]
 			}
 			testName.WriteString(s)
 			if i != len(ss[1:])-1 {


### PR DESCRIPTION
This PR enables -smallscreen arg to wrap the name of the test if it's too long.
- added test name wrap to shortenTestName