### PR TITLE
Downgrade project go version from 1.25 to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mfridman/tparse
 
-go 1.25.0
+go 1.24.0
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0


### PR DESCRIPTION
Because 
```
Run go install github.com/mfridman/tparse@main
  go install github.com/mfridman/tparse@main
  shell: /usr/bin/bash -e {0}
  env:
    GOTOOLCHAIN: local
go: downloading github.com/mfridman/tparse v0.18.1-0.20251127013823-841410793c3d
go: github.com/mfridman/tparse@main: github.com/mfridman/tparse@v0.18.1-0.20251127013823-841410793c3d requires go >= 1.25.0 (running go 1.24.10; GOTOOLCHAIN=local)
Error: Process completed with exit code 1.
```

https://github.com/pressly/goose/actions/runs/19730227750/job/56529429813?pr=775#step:5:8