### PR TITLE
feat: add -output cli option

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -27,6 +27,9 @@ type Options struct {
 	TestTableOptions    TestTableOptions
 	SummaryTableOptions SummaryTableOptions
 
+	// PrintOutput will display test output prefixed with "--- OUTPUT: "
+	PrintOutput bool
+
 	// FollowOutput will follow the raw output as go test is running.
 	FollowOutput        bool           // Output to stdout
 	FollowOutputWriter  io.WriteCloser // Output to a file, takes precedence over FollowOutput
@@ -141,6 +144,12 @@ func display(w io.Writer, summary *parse.GoTestSummary, option Options) {
 			cw.testsTable(packages, option.TestTableOptions)
 		}
 	}
+
+	// Print test output table
+	if option.PrintOutput {
+		cw.outputTable(packages)
+	}
+
 	// Failures (if any) and summary table are always printed.
 	cw.printFailed(packages)
 	cw.summaryTable(packages, option.ShowNoTests, option.SummaryTableOptions, against)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -27,7 +27,7 @@ type Options struct {
 	TestTableOptions    TestTableOptions
 	SummaryTableOptions SummaryTableOptions
 
-	// PrintOutput will display test output prefixed with "--- OUTPUT: "
+	// PrintOutput will display test stdout output.
 	PrintOutput bool
 
 	// FollowOutput will follow the raw output as go test is running.

--- a/internal/app/table_output.go
+++ b/internal/app/table_output.go
@@ -43,7 +43,7 @@ func (c *consoleWriter) outputTable(packages []*parse.Package) {
 	for _, pkg := range packages {
 		printed := false
 		for _, t := range pkg.Tests {
-			if o := t.GetPrintableOutput(); o != "" {
+			if o := t.GetPrintableOutput(); o != "" && t.Status() == parse.ActionPass {
 
 				row := outputRow{
 					packageName: t.Package,

--- a/internal/app/table_output.go
+++ b/internal/app/table_output.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+	"github.com/mfridman/tparse/parse"
+)
+
+type outputRow struct {
+	testName    string
+	packageName string
+	output      string
+}
+
+func (r outputRow) toRow() []string {
+	return []string{
+		r.testName,
+		r.packageName,
+		r.output,
+	}
+}
+
+func (c *consoleWriter) outputTable(packages []*parse.Package) {
+	tbl := newTable(c.format, func(style lipgloss.Style, row, _ int) lipgloss.Style {
+		switch row {
+		case table.HeaderRow:
+		default:
+			style = style.Align(lipgloss.Left)
+		}
+		return style
+	})
+	header := outputRow{
+		testName:    "Test",
+		packageName: "Package",
+		output:      "Output",
+	}
+	tbl.Headers(header.toRow()...)
+	data := table.NewStringData()
+
+	for _, pkg := range packages {
+		printed := false
+		for _, t := range pkg.Tests {
+			if o := t.GetPrintableOutput(); o != "" {
+
+				row := outputRow{
+					packageName: t.Package,
+					testName:    t.Name,
+					output:      strings.TrimRight(o, "\n"),
+				}
+				if data.Rows() != 0 && !printed {
+					// Add a blank row between packages.
+					data.Append(outputRow{}.toRow())
+					printed = true
+				}
+				data.Append(row.toRow())
+			}
+		}
+	}
+
+	if data.Rows() > 0 {
+		fmt.Fprintln(c, tbl.Data(data).Render())
+	}
+}

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ Options:
     -file              Read test output from a file.
     -follow            Follow raw output from go test to stdout.
     -follow-output     Write raw output from go test to a file (takes precedence over -follow).
-    -output     		   Display table for test output to stdout prefixed with "--- OUTPUT: ".
+    -output            Display table for test output to stdout prefixed with "--- OUTPUT: ".
     -include-timestamp Include timestamps in follow output. 
     -progress          Print a single summary line for each package. Useful for long running test suites.
     -compare           Compare against a previous test output file. (experimental)

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ Options:
     -file              Read test output from a file.
     -follow            Follow raw output from go test to stdout.
     -follow-output     Write raw output from go test to a file (takes precedence over -follow).
-    -output            Display table for test output to stdout prefixed with "--- OUTPUT: ".
+    -output            Display table for test output to stdout.
     -include-timestamp Include timestamps in follow output. 
     -progress          Print a single summary line for each package. Useful for long running test suites.
     -compare           Compare against a previous test output file. (experimental)

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ Options:
     -file              Read test output from a file.
     -follow            Follow raw output from go test to stdout.
     -follow-output     Write raw output from go test to a file (takes precedence over -follow).
-		-output     		   Display table for test output to stdout prefixed with "--- OUTPUT: ".
+    -output     		   Display table for test output to stdout prefixed with "--- OUTPUT: ".
     -include-timestamp Include timestamps in follow output. 
     -progress          Print a single summary line for each package. Useful for long running test suites.
     -compare           Compare against a previous test output file. (experimental)

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ var (
 	sortPtr         = flag.String("sort", "name", "")
 	progressPtr     = flag.Bool("progress", false, "")
 	comparePtr      = flag.String("compare", "", "")
+	outputPtr       = flag.Bool("output", false, "")
 	trimPathPtr     = flag.String("trimpath", "", "")
 	// Undocumented flags
 	followVerbosePtr = flag.Bool("follow-verbose", false, "")
@@ -63,6 +64,7 @@ Options:
     -file              Read test output from a file.
     -follow            Follow raw output from go test to stdout.
     -follow-output     Write raw output from go test to a file (takes precedence over -follow).
+		-output     		   Display table for test output to stdout prefixed with "--- OUTPUT: ".
     -include-timestamp Include timestamps in follow output. 
     -progress          Print a single summary line for each package. Useful for long running test suites.
     -compare           Compare against a previous test output file. (experimental)
@@ -161,6 +163,7 @@ func main() {
 			TrimPath: *trimPathPtr,
 			Slow:     *slowPtr,
 		},
+		PrintOutput: *outputPtr,
 		SummaryTableOptions: app.SummaryTableOptions{
 			Trim:     *smallScreenPtr,
 			TrimPath: *trimPathPtr,

--- a/parse/event.go
+++ b/parse/event.go
@@ -138,6 +138,13 @@ const (
 	resultPrefixBench = "--- BENCH: "
 )
 
+var results = []string{
+	resultPrefixPass,
+	resultPrefixFail,
+	resultPrefixSkip,
+	resultPrefixBench,
+}
+
 // Prefix set by user to mark output as printable when -output flag is set
 const OutputPrefix = "--- OUTPUT: "
 
@@ -231,6 +238,20 @@ func (e *Event) IsPanic() bool {
 	}
 	return false
 
+}
+
+func (e *Event) IsStdout() bool {
+	for _, r := range results {
+		if strings.HasPrefix(e.Output, r) {
+			return false
+		}
+	}
+	for _, u := range updates {
+		if strings.HasPrefix(e.Output, u) {
+			return false
+		}
+	}
+	return true
 }
 
 // Action is one of a fixed set of actions describing a single emitted event.

--- a/parse/event.go
+++ b/parse/event.go
@@ -65,7 +65,7 @@ type Event struct {
 	//  }
 	ImportPath string
 
-	// PrintableOutput is the output of the event if it has the prefix "--- OUTPUT: "
+	// PrintableOutput is the stdout output of the event
 	PrintableOutput string
 }
 
@@ -144,9 +144,6 @@ var results = []string{
 	resultPrefixSkip,
 	resultPrefixBench,
 }
-
-// Prefix set by user to mark output as printable when -output flag is set
-const OutputPrefix = "--- OUTPUT: "
 
 // BigResult reports whether the test output is a big pass or big fail
 //

--- a/parse/event.go
+++ b/parse/event.go
@@ -239,12 +239,12 @@ func (e *Event) IsPanic() bool {
 
 func (e *Event) IsStdout() bool {
 	for _, r := range results {
-		if strings.HasPrefix(e.Output, r) {
+		if strings.HasPrefix(strings.TrimSpace(e.Output), r) {
 			return false
 		}
 	}
 	for _, u := range updates {
-		if strings.HasPrefix(e.Output, u) {
+		if strings.HasPrefix(strings.TrimSpace(e.Output), u) {
 			return false
 		}
 	}

--- a/parse/event.go
+++ b/parse/event.go
@@ -64,6 +64,9 @@ type Event struct {
 	//      Output     string
 	//  }
 	ImportPath string
+
+	// PrintableOutput is the output of the event if it has the prefix "--- OUTPUT: "
+	PrintableOutput string
 }
 
 func (e *Event) String() string {
@@ -134,6 +137,9 @@ const (
 	resultPrefixSkip  = "--- SKIP: "
 	resultPrefixBench = "--- BENCH: "
 )
+
+// Prefix set by user to mark output as printable when -output flag is set
+const OutputPrefix = "--- OUTPUT: "
 
 // BigResult reports whether the test output is a big pass or big fail
 //

--- a/parse/process.go
+++ b/parse/process.go
@@ -214,10 +214,11 @@ func (s *GoTestSummary) AddEvent(e *Event) {
 	// no value to the go test output, unless you care to follow how often
 	// tests are paused and for what duration.
 	if e.Action == ActionOutput {
-		if o, f := strings.CutPrefix(e.Output, OutputPrefix); f {
-			e.PrintableOutput = o
-		} else if e.DiscardOutput() {
+		if e.DiscardOutput() {
 			return
+		}
+		if e.IsStdout() {
+			e.PrintableOutput = e.Output
 		}
 	}
 

--- a/parse/process.go
+++ b/parse/process.go
@@ -213,9 +213,14 @@ func (s *GoTestSummary) AddEvent(e *Event) {
 	// Discard noisy output such as "=== CONT", "=== RUN", etc. These add
 	// no value to the go test output, unless you care to follow how often
 	// tests are paused and for what duration.
-	if e.Action == ActionOutput && e.DiscardOutput() {
-		return
+	if e.Action == ActionOutput {
+		if o, f := strings.CutPrefix(e.Output, OutputPrefix); f {
+			e.PrintableOutput = o
+		} else if e.DiscardOutput() {
+			return
+		}
 	}
+
 	pkg, ok := s.Packages[e.Package]
 	if !ok {
 		pkg = newPackage()

--- a/parse/test.go
+++ b/parse/test.go
@@ -2,6 +2,7 @@ package parse
 
 import (
 	"sort"
+	"strings"
 )
 
 // Test represents a single, unique, package test.
@@ -21,6 +22,18 @@ func (t *Test) Elapsed() float64 {
 		}
 	}
 	return f
+}
+
+// Collect test printable output to a single string and return
+func (t *Test) GetPrintableOutput() string {
+	outputs := make([]string, len(t.Events))
+
+	for i, e := range t.Events {
+		outputs[i] = e.PrintableOutput
+	}
+	s := strings.Join(outputs, "")
+
+	return s
 }
 
 // Status reports the outcome of the test represented as a single Action: pass, fail or skip.


### PR DESCRIPTION
# Summary
- Add `-output` cli flag
- Print new table with test stdout output when the above is set

# Motivation
Currently to see any output generated by tests we need to fail on purpose; this obviously not ideal.

# Sample Output
```
╭─────────────────────────────┬───────────────────────────────────────────┬─────────────╮
│            Test             │                  Package                  │   Output    │
├─────────────────────────────┼───────────────────────────────────────────┼─────────────┤
│ TestFindLongestCommonPrefix │ github.com/mfridman/tparse/internal/utils │ TEST OUTPUT │
│                             │                                           │             │
│ TestSortName                │ github.com/mfridman/tparse/tests          │ TEST OUTPUT │
│ TestSummaryCounts           │ github.com/mfridman/tparse/tests          │ TEST OUTPUT │
╰─────────────────────────────┴───────────────────────────────────────────┴─────────────╯
╭────────┬──────────┬───────────────────────────────────────────┬───────┬──────┬──────┬──────╮
│ Status │ Elapsed  │                  Package                  │ Cover │ Pass │ Fail │ Skip │
├────────┼──────────┼───────────────────────────────────────────┼───────┼──────┼──────┼──────┤
│  PASS  │  0.01s   │ github.com/mfridman/tparse/internal/utils │  --   │  12  │  0   │  0   │
│  PASS  │ (cached) │ github.com/mfridman/tparse/parse          │  --   │  43  │  0   │  0   │
│  PASS  │  0.02s   │ github.com/mfridman/tparse/tests          │  --   │ 142  │  0   │  0   │
╰────────┴──────────┴───────────────────────────────────────────┴───────┴──────┴──────┴──────╯
```