### PR TITLE
fix: Empty Lines between non-covered packages

### DIFF
--- a/internal/app/table_tests.go
+++ b/internal/app/table_tests.go
@@ -101,7 +101,7 @@ func (c *consoleWriter) testsTable(packages []*parse.Package, option TestTableOp
 			}
 			data.Append(row.toRow())
 		}
-		if i != (len(packages) - 1) {
+		if len(all) > 0 && i != (len(packages)-1) {
 			// Add a blank row between packages.
 			data.Append(testRow{}.toRow())
 		}


### PR DESCRIPTION
If `go test` also runs with `-v -cover` it can add packages without tests, which is ands up as empty consecutive lines with table.

Closes https://github.com/mfridman/tparse/issues/155